### PR TITLE
RootSpan context does not work with OT instrumenter

### DIFF
--- a/appoptics-opentelemetry-sdk/src/main/java/com/appoptics/api/ext/impl/TraceHandler.java
+++ b/appoptics-opentelemetry-sdk/src/main/java/com/appoptics/api/ext/impl/TraceHandler.java
@@ -247,7 +247,7 @@ public class TraceHandler implements ITraceHandler {
 //            System.out.println(declaredMethod);
 //        }
 //        System.out.println(RootSpan.class.getProtectionDomain().getCodeSource().getLocation());
-        Span rootSpan = RootSpan.fromContextOrNull(Context.current());
+        Span rootSpan = RootSpan.fromTraceId(Span.current().getSpanContext().getTraceId());
         if (rootSpan == null) {
             return false;
         }

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsRootSpanProcessor.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsRootSpanProcessor.java
@@ -1,28 +1,19 @@
 package com.appoptics.opentelemetry.extensions;
 
 import com.appoptics.opentelemetry.core.RootSpan;
-import com.tracelytics.ext.google.common.cache.Cache;
-import com.tracelytics.ext.google.common.cache.CacheBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
-import java.util.concurrent.TimeUnit;
-
 public class AppOpticsRootSpanProcessor implements SpanProcessor {
-    private static Cache<String, Scope> allRootScopes = null; //has to lazy initialize this, otherwise jboss logmanager would have issues
-
-
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {
         SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
         if (!parentSpanContext.isValid() || parentSpanContext.isRemote()) { //then a root span of this service
-            Scope scope = RootSpan.with(parentContext, span).makeCurrent();
-            rootScopes().put(span.getSpanContext().getTraceId(), scope);
+            RootSpan.setRootSpan(span);
         }
     }
 
@@ -35,18 +26,8 @@ public class AppOpticsRootSpanProcessor implements SpanProcessor {
     public void onEnd(ReadableSpan span) {
         SpanContext parentSpanContext = span.toSpanData().getParentSpanContext();
         if (!parentSpanContext.isValid() || parentSpanContext.isRemote()) { //then a root span of this service
-            Scope scope = rootScopes().getIfPresent(span.getSpanContext().getTraceId());
-            if (scope != null) {
-                scope.close();
-            }
+            RootSpan.clearRootSpan(span.getSpanContext().getTraceId());
         }
-    }
-
-    private synchronized Cache<String, Scope> rootScopes() {
-        if (allRootScopes == null) {
-            allRootScopes = CacheBuilder.newBuilder().expireAfterWrite(1200L, TimeUnit.SECONDS).build();
-        }
-        return allRootScopes;
     }
 
     @Override


### PR DESCRIPTION
## Description
The existing `RootSpan` makes use of `io.opentelemetry.context.Context` to store the span instance similar to `io.opentelemetry.instrumentation.api.tracer.ServerSpan`. In theory, this is a good approach as it makes use of the context management in OT, hence we do not have to worry about propagation and cleanups.

Unfortunately this does not seem to work when combined with OT's auto instrumentation.

## Cause
For example, we use `AppOpticsRootSpanProcessor` to set the `RootSpan` and generate a new context as new "current" context. However, such context is later on overwritten by OT's auto instrumentation such as 
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.3.1/instrumentation/tomcat/tomcat-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/Tomcat7ServerHandlerAdvice.java#L33

Therefore using using context to track root span in `AppOpticsRootSpanProcessor` does not work

## Solution
We either have to find some other spots to track root span (outside of `AppOpticsRootSpanProcessor`) or stop using `Context` as the storage of root span within `RootSpan`. And we go for the latter as it's more trivial

Instead of using Context, we are simply using a map to track root span versus trace ID. When a root span is started, `AppOpticsRootSpanProcessor` would set the root span, and on span finish, such span will be removed