### PR TITLE
Logmanager issue with jboss

### DIFF
--- a/appoptics-opentelemetry-sdk/build.gradle
+++ b/appoptics-opentelemetry-sdk/build.gradle
@@ -6,8 +6,7 @@ group = "com.appoptics.agent.java"
 dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:${versions.opentelemetryJavaagentAlpha}")
-
-          compileOnly "com.appoptics.agent.java:core:${versions.appoptics}"
+  compileOnly "com.appoptics.agent.java:core:${versions.appoptics}"
   compileOnly "com.appoptics.agent.java:metrics:${versions.appoptics}"
   compileOnly project(":custom")
   compileOnly project(":core-bootstrap")

--- a/appoptics-opentelemetry-sdk/src/main/java/com/appoptics/api/ext/AgentChecker.java
+++ b/appoptics-opentelemetry-sdk/src/main/java/com/appoptics/api/ext/AgentChecker.java
@@ -9,7 +9,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * TODO this might not be necessary as when the extension is loaded, it should already block for init
+ *  Checker on the OT/AO agent or extension status. Provide a method to block until it's ready (ie ready to trace - remote trace settings are downloaded)
  *
  * @author pluk
  */
@@ -58,9 +58,16 @@ public class AgentChecker {
     public static boolean waitUntilAgentReady(long timeout, TimeUnit unit) {
         if (isExtensionAvailable && serviceKey != null) {
             try {
-                Future<?> future = Initializer.initialize(serviceKey);
-                future.get(timeout, unit);
-                return true;
+                //Future<?> future = Initializer.initialize(serviceKey);
+                Future<?> future = Initializer.getStartupTasksFuture();
+                if (future != null) {
+                    future.get(timeout, unit);
+                    return true;
+                } else {
+                    logger.warning("AppOptics can only be used with javaagent");
+                    return false;
+                }
+
             } catch (Exception e) {
                 logger.warning("Agent is still not ready after waiting for " + timeout + " " + unit);
                 return false;

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}")
   compileOnly("io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}")
   //compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${versions.opentelemetryJavaagentAlpha}")
   compileOnly("org.checkerframework:checker-qual:3.13.0")
   implementation project(path: ":core-bootstrap")

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsAgentListener.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsAgentListener.java
@@ -1,0 +1,14 @@
+package com.appoptics.opentelemetry.extensions;
+
+import com.appoptics.opentelemetry.extensions.initialize.Initializer;
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.AgentListener;
+
+@AutoService(AgentListener.class)
+public class AppOpticsAgentListener implements AgentListener {
+    @Override
+    public void afterAgent(Config config) {
+        Initializer.executeStartupTasks();
+    }
+}

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsTracerProviderConfigurer.java
@@ -12,18 +12,14 @@ import org.slf4j.LoggerFactory;
 
 @AutoService(SdkTracerProviderConfigurer.class)
 public class AppOpticsTracerProviderConfigurer implements SdkTracerProviderConfigurer {
-    private static final String APPOPTICS_SERVICE_KEY = "otel.appoptics.service.key";
     //private Logger log = LoggerFactory.getLogger(AgentInstaller.class);
     private Logger logger = LoggerFactory.getLogger(getClass());
     public AppOpticsTracerProviderConfigurer() {
-        String serviceKey = System.getProperty(APPOPTICS_SERVICE_KEY);
         try {
-            Initializer.initialize(serviceKey);
-            logger.info("Successfully initialized AppOptics OpenTelemetry extensions with service key " + ServiceKeyUtils.maskServiceKey(serviceKey));
+            Initializer.initialize();
         } catch (InvalidConfigException e) {
-            logger.warn("Failed to initialize AppOptics OpenTelemetry extensions due to config error: " + e.getMessage(), e);
+            logger.warn(e.getMessage());
         }
-
     }
 
     @Override

--- a/sdk-extensions-bootstrap/build.gradle
+++ b/sdk-extensions-bootstrap/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 tasks {
   shadowJar {
     classifier = "" //make it overwrite the original file instead of generating an extra one with `-all` suffix
+    relocatePackages(it)
   }
 
   assemble {


### PR DESCRIPTION
### Description
While testing with Wildfly 9/18 with extension jar, we found exception as below: 
```
WARNING: Failed to load the specified log manager class org.jboss.logmanager.LogManager
...
java.lang.RuntimeException: WFLYCTL0079: Failed initializing module org.jboss.as.logging
	at org.jboss.as.controller.extension.ParallelExtensionAddHandler$1.execute(ParallelExtensionAddHandler.java:115)
	at org.jboss.as.controller.AbstractOperationContext.executeStep(AbstractOperationContext.java:999)
	at org.jboss.as.controller.AbstractOperationContext.processStages(AbstractOperationContext.java:743)
	at org.jboss.as.controller.AbstractOperationContext.executeOperation(AbstractOperationContext.java:467)
	at org.jboss.as.controller.OperationContextImpl.executeOperation(OperationContextImpl.java:1413)
	at org.jboss.as.controller.ModelControllerImpl.boot(ModelControllerImpl.java:495)
	at org.jboss.as.controller.AbstractControllerService.boot(AbstractControllerService.java:472)
	at org.jboss.as.controller.AbstractControllerService.boot(AbstractControllerService.java:434)
	at org.jboss.as.server.ServerService.boot(ServerService.java:435)
	at org.jboss.as.server.ServerService.boot(ServerService.java:394)
	at org.jboss.as.controller.AbstractControllerService$1.run(AbstractControllerService.java:374)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: WFLYLOG0078: The logging subsystem requires the log manager to be org.jboss.logmanager.LogManager. The subsystem has not be initialized and cannot be used. To use JBoss Log Manager you must add the system property "java.util.logging.manager" and set it to "org.jboss.logmanager.LogManager"
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
	at org.jboss.as.controller.extension.ParallelExtensionAddHandler$1.execute(ParallelExtensionAddHandler.java:107)
	... 11 more
```

This appears to only happen with the extension approach, the full OT/AO agent seems to work fine (can still have issues, see cause below)

### Cause
The exception is triggered because our code triggers java.util.Logging before jboss does. And it's a well studied problem for our joboe agent that is documented in https://github.com/librato/joboe/issues/542. OpenTelemetry agent is facing similar problem, see https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java#L200

The complete flow
1. Our `Initializer` logic is triggered by OT's agent premain code, it spawns a worker that execute various startup task asynchronously
2. One of the task is starting the Metrics monitor that eventually triggers `com.tracelytics.ext.google.common.cache.CacheBuilder` which calls `java.util.logging.Logger#getLogger`
3. Such call to `java.util.logging.getLogger` will initialize `java.util.logging.Logger`
4. Later on when jboss uses `java.util.logging.getLogger`, it will have conflict as jboss expects itself as the first one that initializes the `java.util.logging.Logger`

Extract of the stack trace of point 2 above
```
<clinit>:181, LogManager (java.util.logging)
demandLogger:448, Logger (java.util.logging)
getLogger:502, Logger (java.util.logging)
<clinit>:224, CacheBuilder (com.tracelytics.ext.google.common.cache)
createMeasurementCache:38, MetricMeasurementSpanReporter (com.tracelytics.joboe.span.impl)
<init>:33, MetricMeasurementSpanReporter (com.tracelytics.joboe.span.impl)
<init>:18, InboundMetricMeasurementSpanReporter (com.tracelytics.joboe.span.impl)
<clinit>:15, InboundMetricMeasurementSpanReporter (com.tracelytics.joboe.span.impl)
<clinit>:23, SpanMetricsCollector (com.tracelytics.monitor.metrics)
buildSpanMetricsCollector:34, AppOpticsInboundMetricsSpanProcessor (com.appoptics.opentelemetry.extensions)
buildMetricsMonitor:112, Initializer$2$1$1 (com.appoptics.opentelemetry.extensions.initialize)
buildMonitors:45, SystemMonitorFactoryImpl (com.tracelytics.monitor)
build:121, Initializer$2$1 (com.appoptics.opentelemetry.extensions.initialize)
```

Take note that the OT/AO agent seems to work fine as we run [shadowing](https://github.com/appoptics/opentelemetry-custom-distro/blob/master/gradle/shadow.gradle#L5) on the agent, which will redirect all `java.util.logging.Logger` calls to a [`PatchLogger`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java) 

Therefore our `MetricMeasurementSpanReporter` reference to `java.util.logging.Logger` would be rewritten. 

The same shadowing is not applied to our `sdk-extension-shaded` artifact, hence the issue.

Take note that OT/AO agent is not completely immune to this logger issue, in fact it can still be an issue if the timing is right. For example if our `MetricsCollector` starts collecting JMX metrics before jboss set the logger. it will still have issues:
```
<clinit>:181, LogManager (java.util.logging)
demandLogger:448, Logger (java.util.logging)
getLogger:502, Logger (java.util.logging)
<init>:55, ClassLogger (com.sun.jmx.remote.util)
<clinit>:365, NotificationBroadcasterSupport (javax.management)
<init>:72, MBeanServerDelegate (javax.management)
<init>:100, MBeanServerDelegateImpl (com.sun.jmx.mbeanserver)
newMBeanServerDelegate:1374, JmxMBeanServer (com.sun.jmx.mbeanserver)
newMBeanServerDelegate:66, MBeanServerBuilder (javax.management)
newMBeanServer:321, MBeanServerFactory (javax.management)
createMBeanServer:231, MBeanServerFactory (javax.management)
createMBeanServer:192, MBeanServerFactory (javax.management)
getPlatformMBeanServer:469, ManagementFactory (java.lang.management)
collect:138, JMXCollector (com.tracelytics.monitor.metrics)
```

This is because the shadowing does not cover core java jmx code which also references `java.util.logging.Logger`

## Solution
Firstly, we should do the same shadowing relocate on `sdk-extension-shaded`

Secondly, we can make use of the `AgentListener` SPI, which list tasks to be executed after the agent is "safely installed", which take into [consideration](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java#L218) of LogManager overwrite issues.

Therefore we created a `AppOpticsAgentListener` that invoke `Initializer#executeStartupTasks to carry out the agent start tasks. 
