### PR TITLE
AO-20095: Replace deprecated maven plugin

### DIFF
--- a/appoptics-opentelemetry-sdk/build.gradle
+++ b/appoptics-opentelemetry-sdk/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-apply plugin: "maven"
+apply plugin: "maven-publish"
 
 group = "com.appoptics.agent.java"
 


### PR DESCRIPTION
The `maven` plugin is replaced by `maven-publish` starting from Gradle 7.0