### PR TITLE
AO-20411 NH-2306: Fall back to default profiler setting if no one exists

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
@@ -378,11 +378,12 @@ public class Initializer {
             finalProfilerSetting = new ProfilerSetting(finalEnabled, profilerSettingsFromConfigFile.getExcludePackages(), finalInterval, profilerSettingsFromConfigFile.getCircuitBreakerDurationThreshold(), profilerSettingsFromConfigFile.getCircuitBreakerCountThreshold());
         } else if (profilerEnabledFromEnvVar != null || profilerIntervalFromEnvVar != null) {
             finalProfilerSetting = new ProfilerSetting(profilerEnabledFromEnvVar != null ? profilerEnabledFromEnvVar : false, profilerIntervalFromEnvVar != null ? profilerIntervalFromEnvVar : ProfilerSetting.DEFAULT_INTERVAL);
+        } else {
+            finalProfilerSetting = new ProfilerSetting(false, ProfilerSetting.DEFAULT_INTERVAL);
         }
 
-        if (finalProfilerSetting != null) {
-            configs.put(ConfigProperty.PROFILER, finalProfilerSetting, true);
-        }
+        // always put a profiler setting as we fall back to a default (disabled) one if no setting exists.
+        configs.put(ConfigProperty.PROFILER, finalProfilerSetting, true);
 
         ConfigManager.initialize(configs);
     }


### PR DESCRIPTION
NH-2306

If the user provides a config file without a profiler setting, the current code will pass in a null config object to the Profiler initialization which causes panic. This PR makes it fall back to a default (disabled) profiler setting so the profiler won't get started when the user doesn't explicitly mention the profiler in the config file.

There is a default built-in config file which has a default profiler setting. It means if the user doesn't have a config file at all the profiler will be started with the default setting.