### PR TITLE
NH-2307: Config file path via env var

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsTracerProviderConfigurer.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 
 @AutoService(SdkTracerProviderConfigurer.class)
 public class AppOpticsTracerProviderConfigurer implements SdkTracerProviderConfigurer {
-    //private Logger log = LoggerFactory.getLogger(AgentInstaller.class);
     private Logger logger = LoggerFactory.getLogger(getClass());
     public AppOpticsTracerProviderConfigurer() {
         try {

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
@@ -65,6 +65,7 @@ public class Initializer {
             throw e;
         } finally {
             reportInit(exception);
+            serviceKey = (String)ConfigManager.getConfig(ConfigProperty.AGENT_SERVICE_KEY);
             logger.info("Successfully initialized AppOptics OpenTelemetry extensions with service key " + ServiceKeyUtils.maskServiceKey(serviceKey));
             return future;
         }


### PR DESCRIPTION
Make the config file path configurable via an environment variable and let the agent print the correct service key.

See also: 
https://github.com/librato/joboe/pull/1506
https://swicloud.atlassian.net/browse/NH-2307