### PR TITLE
NH-4887: interim rebranding

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporterProvider.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporterProvider.java
@@ -1,6 +1,7 @@
 package com.appoptics.opentelemetry.extensions;
 
 
+import com.appoptics.opentelemetry.extensions.initialize.config.ConfigConstants;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
@@ -8,11 +9,9 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 @AutoService(ConfigurableSpanExporterProvider.class)
 public class AppOpticsSpanExporterProvider implements ConfigurableSpanExporterProvider {
-    private static final String APPOPTICS_SERVICE_KEY = "otel.appoptics.service.key";
-
     @Override
     public SpanExporter createExporter(ConfigProperties config) {
-        final String serviceKey = config.getString(APPOPTICS_SERVICE_KEY);
+        final String serviceKey = config.getString(ConfigConstants.APPOPTICS_SERVICE_KEY);
         return AppOpticsSpanExporter.newBuilder(serviceKey).build();
     }
 

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
@@ -30,8 +30,6 @@ import java.util.concurrent.Future;
 public class Initializer {
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Initializer.class.getName());
     private static final String VERSION_PROPERTIES_FILE = "/version.properties";
-    private static final String APPOPTICS_SERVICE_KEY = "otel.appoptics.service.key";
-    private static final String APPOPTICS_CONFIG_FILE = "otel.appoptics.configfile";
     private static Future<?> startupTasksFuture;
 
     static {
@@ -51,7 +49,7 @@ public class Initializer {
     }
 
     public static Future<?> initialize() throws InvalidConfigException {
-        String serviceKey = System.getProperty(APPOPTICS_SERVICE_KEY);
+        String serviceKey = System.getProperty(ConfigConstants.APPOPTICS_SERVICE_KEY);
 
         InvalidConfigException exception = null;
         Future<?> future = null;
@@ -221,7 +219,7 @@ public class Initializer {
             container.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, explicitServiceKey);
         }
 
-        String configFile = System.getProperty(APPOPTICS_CONFIG_FILE);
+        String configFile = System.getProperty(ConfigConstants.APPOPTICS_CONFIG_FILE);
         if (configFile != null) {
             container.putByStringValue(ConfigProperty.AGENT_CONFIG, configFile);
         }

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/config/ConfigConstants.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/config/ConfigConstants.java
@@ -4,4 +4,9 @@ public final class ConfigConstants {
     public static final int MAX_SQL_QUERY_LENGTH_LOWER_LIMIT = 2 * 1024;
     public static final int MAX_SQL_QUERY_LENGTH_UPPER_LIMIT = 128 * 1024;
     public static final int SAMPLE_RESOLUTION = 1000000;
+    public static final String PRODUCT_NAME = "solarwinds";
+    public static final String PRODUCT_NAME_UPPERCASE = "SOLARWINDS";
+    public static final String CONFIG_PREFIX = "otel." + ConfigConstants.PRODUCT_NAME;
+    public static final String APPOPTICS_SERVICE_KEY = CONFIG_PREFIX + ".service.key";
+    public static final String APPOPTICS_CONFIG_FILE = CONFIG_PREFIX + ".configfile";
 }


### PR DESCRIPTION
Rename `APPOPTICS*` or `appoptics*` to `SOLARWINDS*` or `solarwinds*`in all user-facing places, mainly environment variables and JVM arguments.


See also: 
https://swicloud.atlassian.net/browse/NH-4887
https://github.com/librato/joboe/pull/1510