### PR TITLE
[WIP] exclude joboe dependencies from instrumentation

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsIgnoredTypesConfigurer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsIgnoredTypesConfigurer.java
@@ -1,0 +1,14 @@
+package com.appoptics.opentelemetry.extensions;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+
+@AutoService(IgnoredTypesConfigurer.class)
+public class AppOpticsIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
+    @Override
+    public void configure(Config config, IgnoredTypesBuilder builder) {
+        builder.ignoreClass("com.appoptics.ext.");
+    }
+}


### PR DESCRIPTION
This is to exclude the joboe core libraries and the dependency libraries from being instrumented.