### PR TITLE
NH-7234: Report agent version

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -32,7 +32,6 @@ CopySpec isolateSpec() {
   }
 }
 
-
 tasks {
   shadowJar {
     dependsOn ':custom:shadowJar'
@@ -54,8 +53,8 @@ tasks {
       attributes.put("Premain-Class", "io.opentelemetry.javaagent.OpenTelemetryAgent")
       attributes.put("Can-Redefine-Classes", "true")
       attributes.put("Can-Retransform-Classes", "true")
-      attributes.put("Implementation-Vendor", "Demo")
-      attributes.put("Implementation-Version", "demo-${project.version}-otel-${versions.opentelemetryJavaagent}")
+      attributes.put("Implementation-Vendor", "SolarWinds Inc.")
+      attributes.put("Implementation-Version", "${versions.agent}")
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,8 @@ subprojects {
       bytebuddy             : "1.10.18",
       guava                 : "30.1-jre",
       appopticsCore         : "7.0.2",
-      appopticsMetrics      : "7.0.0"
+      appopticsMetrics      : "7.0.0",
+      agent                 : "0.0.1" // the custom distro agent version
     ]
     versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"
     versions.opentelemetryJavaagentAlpha = "${versions.opentelemetryJavaagent}-alpha"

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Future;
 
 public class Initializer {
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Initializer.class.getName());
-    private static final String VERSION_PROPERTIES_FILE = "/version.properties";
     private static Future<?> startupTasksFuture;
 
     static {
@@ -421,14 +420,7 @@ public class Initializer {
         Future<Result> future = null;
         try {
             String layerName = (String) ConfigManager.getConfig(ConfigProperty.AGENT_LAYER);
-            Properties versionsProperties = new Properties();
-            versionsProperties.load(Initializer.class.getResourceAsStream(VERSION_PROPERTIES_FILE));
-            String version = versionsProperties.getProperty("agent.version");
-            if (version == null) {
-                LOGGER.warn("Could not locate agent.version in " + VERSION_PROPERTIES_FILE + " for version...");
-            }
-
-            future = reportLayerInit(layerName, version, configException);
+            future = reportLayerInit(layerName, getVersion(), configException);
         }
         catch (Exception e) {
             LOGGER.warn("Failed to post init message: " + (e.getMessage() != null ? e.getMessage() : e.toString()));
@@ -437,6 +429,10 @@ public class Initializer {
             }
         }
         return future;
+    }
+
+    private static String getVersion() {
+        return Initializer.class.getPackage().getImplementationVersion();
     }
 
     private static Future<Result> reportLayerInit(final String layer, final String version, final Throwable configException) throws ClientException {

--- a/custom/src/main/resources/version.properties
+++ b/custom/src/main/resources/version.properties
@@ -1,1 +1,0 @@
-agent.version=${agent.version}


### PR DESCRIPTION
This PR reports the agent version to the collector via the `__Init` message.
The version is extracted from the manifest's `Implementation-Version` property. Note that we don't need the standalone `version.properties` file anymore so it's removed.


## Test
This is what it reports now:
```{"Java.Version":"11.0.12","Java.LastRestart":1642624827372470,"Label":"single","__Init":true,"Java.AppOptics.Opentelemetry.Version":"0.0.1"}```

## See Also
https://swicloud.atlassian.net/browse/NH-7234