### PR TITLE
NH-12088: Move call depth key to instrumentation advice class

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -5,7 +5,6 @@
 
 package com.appoptics.opentelemetry.instrumentation.servlet.v3_0;
 
-import com.appoptics.opentelemetry.instrumentation.servlet.common.service.CallDepthKeyHolder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -35,7 +34,7 @@ public class Servlet3Advice {
     if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
       return;
     }
-    CallDepth callDepth = CallDepth.forClass(CallDepthKeyHolder.getCallDepthKey());
+    CallDepth callDepth = CallDepth.forClass(getCallDepthKey());
     if (callDepth.getAndIncrement() > 0) {
       return;
     }
@@ -59,5 +58,10 @@ public class Servlet3Advice {
       return in;
     }
     return in.replace("####", "=").replace("....", ",");
+  }
+
+  public static Class<?> getCallDepthKey() {
+    class Key {}
+    return Key.class;
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
@@ -5,7 +5,6 @@
 
 package com.appoptics.opentelemetry.instrumentation.servlet.v5_0.service;
 
-import com.appoptics.opentelemetry.instrumentation.servlet.common.service.CallDepthKeyHolder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -31,7 +30,7 @@ public class JakartaServletServiceAdvice {
         if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
             return;
         }
-        CallDepth callDepth = CallDepth.forClass(CallDepthKeyHolder.getCallDepthKey());
+        CallDepth callDepth = CallDepth.forClass(getCallDepthKey());
         if (callDepth.getAndIncrement() > 0) {
             return;
         }
@@ -55,5 +54,10 @@ public class JakartaServletServiceAdvice {
             return in;
         }
         return in.replace("####", "=").replace("....", ",");
+    }
+
+    public static Class<?> getCallDepthKey() {
+        class Key {}
+        return Key.class;
     }
 }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/common/service/CallDepthKeyHolder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/common/service/CallDepthKeyHolder.java
@@ -1,8 +1,0 @@
-package com.appoptics.opentelemetry.instrumentation.servlet.common.service;
-
-public class CallDepthKeyHolder {
-    public static Class<?> getCallDepthKey() {
-        class Key {}
-        return Key.class;
-    }
-}


### PR DESCRIPTION
Move the call depth key class to the instrumentation advice class to get rid of the classloading issue.

See https://swicloud.atlassian.net/browse/NH-12088?focusedCommentId=306229 for more details.