### PR TITLE
Release v0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
       opentelemetryJavaagent: "1.12.1",
       bytebuddy             : "1.12.6",
       guava                 : "30.1-jre",
-      appopticsCore         : "7.3.0",
+      appopticsCore         : "7.5.0",
       agent                 : "0.8.0" // the custom distro agent version
     ]
     versions.appopticsMetrics = "${versions.appopticsCore}" // they share the same version now


### PR DESCRIPTION
What's New:
- Added the agent-ready checker API.
- Upgraded OpenTelemetry Java agent dependency to v1.12.1.
- Updated to the latest collector endpoint.
- Added a benchmark suite (based on the OpenTelemetry Java agent's benchmark-overhead suite).
- Reduced the artifact size by half (from about 50 MB to 25 MB).
- Some internal clean-ups and dependency upgrades.