### PR TITLE
NH-9407: Fix artifact name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Set agent version env
       run: |
-        echo "AGENT_VERSION=v$(cd agent/build/libs && unzip -p solarwinds-apm-agent-all.jar META-INF/MANIFEST.MF | grep Implementation-Version | awk '{ print $2 }')" >> $GITHUB_ENV
+        echo "AGENT_VERSION=v$(cd agent/build/libs && unzip -p solarwinds-apm-agent.jar META-INF/MANIFEST.MF | grep Implementation-Version | awk '{ print $2 }')" >> $GITHUB_ENV
     - name: Release and upload artifacts
       run: gh release create ${{ env.AGENT_VERSION }} --title "${{ env.AGENT_VERSION }}" --target ${{ github.ref_name }} --draft agent/build/libs/*.jar
       env:

--- a/benchmark/src/test/java/io/opentelemetry/agents/LatestSolarwindsAgentResolver.java
+++ b/benchmark/src/test/java/io/opentelemetry/agents/LatestSolarwindsAgentResolver.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public class LatestSolarwindsAgentResolver {
     private static final String NH_URL = "https://api.github.com/repos/appoptics/opentelemetry-java-instrumentation-custom-distro/releases/latest";
     private static final String AO_URL = "https://files.appoptics.com/java/latest/appoptics-agent.jar";
-    private static final String NH_AGENT_JAR_NAME = "solarwinds-apm-agent-all.jar";
+    private static final String NH_AGENT_JAR_NAME = "solarwinds-apm-agent.jar";
     private static final String AO_AGENT_JAR_NAME = "appoptics-agent.jar";
     public static boolean useAOAgent = "AO".equals(System.getenv("AGENT_TYPE"));
     Optional<Path> resolve() throws Exception {


### PR DESCRIPTION
(Reuse the ticket NH-9407 to fix this build glitch)

It's found that the GH release workflow and the benchmark suite are broken a bit because of the jar file name is changed from `...agent-all.jar` to `...agent.jar`.

This PR fixed the issue.