### PR TITLE
NH-15825: Minimal required keys for config file

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/Initializer.java
@@ -284,7 +284,7 @@ public class Initializer {
             }
 
             new JsonConfigReader(Initializer.class.getResourceAsStream("/" + CONFIG_FILE)).read(container);
-            LOGGER.info("Finished reading built-in default settings.");
+            LOGGER.debug("Finished reading built-in default settings.");
         }
         catch (InvalidConfigException e) {
             exceptions.add(new InvalidConfigReadSourceException(e.getConfigProperty(), ConfigSourceType.JSON_FILE, location, container, e));


### PR DESCRIPTION
Currently if a config file is provided, it needs to define a bunch of settings, many of which should not be required by default.
This PR removes these "required" settings for the config file. You can work from a blank config file and add what you want only now.

See also https://swicloud.atlassian.net/browse/NH-15825