### PR TITLE
NH-20931: Disable agent for old JDKs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ subprojects {
       opentelemetryJavaagent: "1.12.1",
       bytebuddy             : "1.12.6",
       guava                 : "30.1-jre",
-      appopticsCore         : "7.7.1",
-      agent                 : "0.12.1" // the custom distro agent version
+      appopticsCore         : "7.8.0",
+      agent                 : "0.13.0" // the custom distro agent version
     ]
     versions.appopticsMetrics = "${versions.appopticsCore}" // they share the same version now
     versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsTracerProviderConfigurer.java
@@ -8,6 +8,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.tracelytics.util.JavaRuntimeVersionChecker;
 
 
 @AutoService(SdkTracerProviderConfigurer.class)
@@ -22,7 +23,7 @@ public class AppOpticsTracerProviderConfigurer implements SdkTracerProviderConfi
 
     static {
         try {
-            if (!isJDKSupported()) {
+            if (!JavaRuntimeVersionChecker.isJdkVersionSupported()) {
                 throw new UnsupportedJdkVersion(System.getProperty("java.version"));
             }
             Initializer.initialize();
@@ -32,12 +33,6 @@ public class AppOpticsTracerProviderConfigurer implements SdkTracerProviderConfi
         }
     }
     public AppOpticsTracerProviderConfigurer() {
-    }
-
-    public static boolean isJDKSupported() {
-        String version = System.getProperty("java.version");
-        // TODO
-        return true;
     }
 
     public static boolean getAgentEnabled() {


### PR DESCRIPTION
This PR add a Java runtime version checker and it will disable the agent when the runtime is not supported.

See the related PR in Joboe: https://github.com/librato/joboe/pull/1567