### PR TITLE
NH-22808 Added .whitesource config to enable Mend scanning

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,22 @@
+{
+  "scanSettings": {
+    "configMode": "AUTO",
+    "configExternalURL": "",
+    "projectToken": "",
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff",
+    "useMendCheckNames": true
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW",
+    "issueType": "DEPENDENCY"
+  },
+  "remediateSettings": {
+    "workflowRules": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Apparently we have higher level Mend integration where simply putting in a Mend config file should enable the repo to be scanned.