### PR TITLE
NH-23316: Bump up version to v0.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
       bytebuddy             : "1.12.6",
       guava                 : "30.1-jre",
       appopticsCore         : "7.8.0",
-      agent                 : "0.14.0-alpha2" // the custom distro agent version
+      agent                 : "0.14.0" // the custom distro agent version
     ]
     versions.appopticsMetrics = "${versions.appopticsCore}" // they share the same version now
     versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"


### PR DESCRIPTION
This PR bumps up the version to v0.14.0 before cut off a new release