### PR TITLE
NH-26277 exporter updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
       bytebuddy             : "1.12.6",
       guava                 : "30.1-jre",
       appopticsCore         : "7.8.0",
-      agent                 : "0.14.0" // the custom distro agent version
+      agent                 : "0.14.1" // the custom distro agent version
     ]
     versions.appopticsMetrics = "${versions.appopticsCore}" // they share the same version now
     versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporter.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporter.java
@@ -44,6 +44,14 @@ public class AppOpticsSpanExporter implements SpanExporter {
 
                     final Metadata spanMetadata = new Metadata(w3cContext);
                     spanMetadata.randomizeOpID(); //get around the metadata logic, this op id is not used
+                    // set spanMetadata into the current Context so that after the initial event, the metadata
+                    // does not need to be manually managed for event creation / linkage.  Context is updated
+                    // with the metadata of the last reported event.
+                    Context.setMetadata(spanMetadata);
+
+                    // create new event with an override metadata from the OTel spanData (w3cContext)
+                    // and link to OTel parent (if present).
+                    // do this with EventImpl instead of Context because we need to use the addEdge param.
                     Event entryEvent;
                     if (parentMetadata != null) {
                         entryEvent = new EventImpl(parentMetadata, w3cContext, true);
@@ -68,7 +76,7 @@ public class AppOpticsSpanExporter implements SpanExporter {
                             "sw.span_kind", spanData.getKind().toString());
                     entryEvent.setTimestamp(spanData.getStartEpochNanos() / 1000);
                     entryEvent.addInfo(getEventKvs(spanData.getAttributes()));
-                    entryEvent.report(spanMetadata);
+                    entryEvent.report();
 
                     for (EventData event : spanData.getEvents()) {
                         if (SemanticAttributes.EXCEPTION_EVENT_NAME.equals(event.getName())) {
@@ -78,16 +86,19 @@ public class AppOpticsSpanExporter implements SpanExporter {
                         }
                     }
 
-                    final Metadata exitMetadata = Util.buildSpanExitMetadata(spanData.getSpanContext()); //exit ID has to be generated
-                    final Event exitEvent = new EventImpl(spanMetadata, exitMetadata.toHexString(),true);
+                    final Event exitEvent = Context.createEvent();
                     exitEvent.addInfo(
                             "Label", "exit",
-                            "Layer", spanName);
-
+                            "Layer", spanName,
+                            "sw.span_status_code", spanData.getStatus().getStatusCode().toString(),
+                            "sw.span_status_message", spanData.getStatus().getDescription());
                     exitEvent.setTimestamp(spanData.getEndEpochNanos() / 1000);
-                    exitEvent.report(spanMetadata);
+                    exitEvent.report();
                 } catch (OboeException e) {
                     e.printStackTrace();
+                } finally {
+                    // clear Context for the next OTel span, which will initialize it with w3cContext
+                    Context.clearMetadata();
                 }
             }
         }
@@ -109,7 +120,6 @@ public class AppOpticsSpanExporter implements SpanExporter {
         if (message == null) {
             message = "";
         }
-
         event.addInfo("Label", "error",
                     "Spec", "error",
                     "ErrorClass", attributes.get(SemanticAttributes.EXCEPTION_TYPE),
@@ -122,7 +132,6 @@ public class AppOpticsSpanExporter implements SpanExporter {
         for (Map.Entry<AttributeKey<?>, Object> keyValue : otherKvs.entrySet()) {
             event.addInfo(keyValue.getKey().getKey(), keyValue.getValue());
         }
-
         event.setTimestamp(eventData.getEpochNanos() / 1000); //convert to micro second
         event.report();
     }
@@ -130,9 +139,9 @@ public class AppOpticsSpanExporter implements SpanExporter {
     private void reportInfoEvent(EventData eventData) {
         final Event event = Context.createEvent();
         final Attributes attributes = eventData.getAttributes();
-
-        event.addInfo("Label", "info");
-
+        event.addInfo(
+            "Label", "info",
+            "sw.event_name", eventData.getName());
         final Map<AttributeKey<?>, Object> otherKvs = filterAttributes(attributes);
         for (Map.Entry<AttributeKey<?>, Object> keyValue : otherKvs.entrySet()) {
             event.addInfo(keyValue.getKey().getKey(), keyValue.getValue());
@@ -163,58 +172,16 @@ public class AppOpticsSpanExporter implements SpanExporter {
         return CompletableResultCode.ofSuccess();
     }
 
-
-
-
-    private static final Map<String, String> ATTRIBUTE_TO_TAG = new HashMap<String, String>();
-    private static final Map<String, TypeConverter<?>> TAG_VALUE_TYPE = new HashMap<String, TypeConverter<?>>();
-    static {
-        ATTRIBUTE_TO_TAG.put("http.status_code", "Status");
-        ATTRIBUTE_TO_TAG.put("net.peer.ip", "ClientIP");
-        ATTRIBUTE_TO_TAG.put("http.url", "URL");
-        ATTRIBUTE_TO_TAG.put("http.method", "HTTPMethod");
-        ATTRIBUTE_TO_TAG.put("db.connection_string", "RemoteHost");
-        ATTRIBUTE_TO_TAG.put("db.system", "Flavor");
-        ATTRIBUTE_TO_TAG.put("db.statement", "Query");
-        ATTRIBUTE_TO_TAG.put("db.url", "RemoteHost");
-        TAG_VALUE_TYPE.put("Status", IntConverter.INSTANCE);
-    }
-
     private Map<String,?> getEventKvs(Attributes inputAttributes) {
         final Map<AttributeKey<?>, Object> attributes = filterAttributes(inputAttributes);
         final Map<String, Object> tags = new HashMap<String, Object>();
         for (Map.Entry<AttributeKey<?>, Object> entry : attributes.entrySet()) {
             Object attributeValue = entry.getValue();
             final String attributeKey = entry.getKey().getKey();
-            if (ATTRIBUTE_TO_TAG.containsKey(attributeKey)) {
-                final String tagKey = ATTRIBUTE_TO_TAG.get(attributeKey);
-                if (TAG_VALUE_TYPE.containsKey(tagKey)) {
-                    attributeValue = TAG_VALUE_TYPE.get(tagKey).convert(attributeValue);
-                }
-                tags.put(tagKey, attributeValue);
-            }
 
             tags.put(attributeKey, attributeValue);
         }
         return tags;
-    }
-
-    interface TypeConverter<T> {
-        T convert(Object rawValue);
-    }
-
-    private static class IntConverter implements TypeConverter<Integer> {
-        static final IntConverter INSTANCE = new IntConverter();
-        @Override
-        public Integer convert(Object rawValue) {
-            if (rawValue instanceof Number) {
-                return ((Number) rawValue).intValue();
-            } else if (rawValue instanceof String) {
-                return Integer.valueOf((String) rawValue);
-            } else {
-                return null;
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
## Jira 
https://swicloud.atlassian.net/browse/NH-26277

## Changes
1. Fix reporting of error and info events -- before this change, the Java instrumentation was not exporting `error` and `info` events because the call to [Context.createEvent()](https://github.com/appoptics/solarwinds-apm-java/blob/f9d6bcf173a9fd598384e8f757294368bb6db757/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporter.java#L131) in the exporter always got a null no-op context.  This PR switches to using `Context` instead of manual management of metadata to make the Context available to any subsequent event created for the OTel span.  I'm guessing when the exporter was first created the joboe core library had not been changed to support W3C trace context thus the exporter was manipulating metadata manually but neglected to do that for the error and info event creation.
2. Add span status code and message -- POC and subject to change since we'd want to discuss this for all OTel custom distros.
3. Remove OTel-to-AO KV translation -- again, probably leftover from early POC days where there was no SWO and translation was needed to check the trace against AO.
4. Bump version for easier testing -- tests below use RC build 0.14.1 from staging https://agent-binaries.global.st-ssp.solarwinds.com/?prefix=apm/java/

## Test
* `javatest` app -- modified an existing AO Java test application to produce OTel span `event`s which should be exported as AO `error` or `info` events: https://github.com/librato/joboe/compare/otel...otel-testbed.  
* `auth-service` app -- from [the NHdemo stack]( https://github.com/appoptics/NHdemo/tree/main/auth-service).

Test apps instrumented with GA or RC (built from this PR) version of the library.

### `javatest` app
HTTP request with exception and SDK created exception and info events, to verify changes 1, 2 and 3

* SWO
  * [javatest-ga](https://my.na-01.cloud.solarwinds.com/140638900734749696/entities/services/e-1527513536478724096/overview)
    * example traces:
      * SDK created exception and info events -- https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/595E6FD624E2D78E8DE2FC495FE50439/DDC2927CCBA9EFC0/details
      * HTTP request with exception -- https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/0F5276A315D59EC43AB9B72333503D4A/86754597E81E9CBC/details
  * [javatest-rc](https://my.na-01.cloud.solarwinds.com/140638900734749696/entities/services/e-1527511830664589312/overview)
    * example traces:
      * SDK created exception and info events -- https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/26245FEDE5D1F1AA8F6E4D7CF52947BA/44D1E0D4189433FF/details
      * HTTP request with exception -- https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/1571AA3E7C4B137A82B342BB519B0232/6A579606DE9BBCA9/details
* AO
  * [javatest-ga](https://my-stg.appoptics.com/apm/225844/services/javatest-ga?duration=3600) 
    * example traces:
      * SDK created exception and info events -- https://my-stg.appoptics.com/apm/225844/services/javatest-ga/traces/D8B5DE2471926744F22BF97ACCE7935200000000
      * HTTP request with exception -- https://my-stg.appoptics.com/apm/225844/services/javatest-ga/traces/8CE8F7963A873220C34F57014110F82900000000
  * [javatest-rc](https://my-stg.appoptics.com/apm/225844/services/javatest-rc?duration=3600)
    * example traces:
      * SDK created exception and info events -- https://my-stg.appoptics.com/apm/225844/services/javatest-rc/traces/7143FECFA10A8782782D5C387DBE347E00000000
      * HTTP request with exception -- https://my-stg.appoptics.com/apm/225844/services/javatest-rc/traces/AF8E2BC9D55116F31115E2EED378B2A500000000

### `auth-service` app
DB and Cache calls and part of distributed trace, to verify changes 1 and 3

* SWO
  * [auth-service-ga](https://my.na-01.cloud.solarwinds.com/140638900734749696/entities/services/e-1528896481919971329/overview)
    * example traces:
      * Database -- https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/37ADE68F3EC40C639EF8C162A7309765/B53075C7040C574F/details
  * [auth-service-rc](https://my.na-01.cloud.solarwinds.com/140638900734749696/entities/services/e-1528896481919971328/overview)
    * example traces:
      * Database -- https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/FACF50026B097092586D7073D0A0036B/45DB08C8436C53DE/details
* AO
  * [auth-service-ga](https://my-stg.appoptics.com/apm/225844/services/auth-service-ga?duration=3600)
    * example traces:
      * Database -- https://my-stg.appoptics.com/apm/225844/services/auth-service-ga/traces/223570DB0504AA9E2A66378F0EC0134F00000000
  * [auth-service-rc](https://my-stg.appoptics.com/apm/225844/services/auth-service-rc?duration=3600)
    * example traces:
      * Database -- https://my-stg.appoptics.com/apm/225844/services/auth-service-rc/traces/C21A662468FB07196401ECB16C9312E000000000