### PR TITLE
NH-26280: Java: x-trace response header missing after initial requests

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -8,15 +8,15 @@ package com.appoptics.opentelemetry.instrumentation.servlet.v3_0;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("unused")
 public class Servlet3Advice {
@@ -31,14 +31,14 @@ public class Servlet3Advice {
       @Advice.This(typing = Assigner.Typing.DYNAMIC) Object servletOrFilter,
       @Advice.Argument(value = 0, readOnly = false) ServletRequest request,
       @Advice.Argument(value = 1, readOnly = false) ServletResponse response) {
-    if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
-      return;
+    if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+      HttpServletResponse httpServletResponse = (HttpServletResponse)response;
+      if (httpServletResponse.containsHeader(XTRACE_HEADER)) {
+        LoggerFactory.getLogger(servletOrFilter.getClass()).debug("{} header exists. Skipping injection.", XTRACE_HEADER);
+      } else {
+        injectXTraceHeader(response);
+      }
     }
-    CallDepth callDepth = CallDepth.forClass(getCallDepthKey());
-    if (callDepth.getAndIncrement() > 0) {
-      return;
-    }
-    injectXTraceHeader(response);
   }
 
   public static void injectXTraceHeader(ServletResponse response) {
@@ -60,8 +60,4 @@ public class Servlet3Advice {
     return in.replace("####", "=").replace("....", ",");
   }
 
-  public static Class<?> getCallDepthKey() {
-    class Key {}
-    return Key.class;
-  }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/com/appoptics/opentelemetry/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
@@ -8,13 +8,13 @@ package com.appoptics.opentelemetry.instrumentation.servlet.v5_0.service;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("unused")
 public class JakartaServletServiceAdvice {
@@ -27,14 +27,14 @@ public class JakartaServletServiceAdvice {
             @Advice.This(typing = Assigner.Typing.DYNAMIC) Object servletOrFilter,
             @Advice.Argument(value = 0, readOnly = false) ServletRequest request,
             @Advice.Argument(value = 1, readOnly = false) ServletResponse response) {
-        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
-            return;
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+            HttpServletResponse httpServletResponse = (HttpServletResponse)response;
+            if (httpServletResponse.containsHeader(XTRACE_HEADER)) {
+                LoggerFactory.getLogger(servletOrFilter.getClass()).debug("{} header exists. Skipping injection.", XTRACE_HEADER);
+            } else {
+                injectXTraceHeader(response);
+            }
         }
-        CallDepth callDepth = CallDepth.forClass(getCallDepthKey());
-        if (callDepth.getAndIncrement() > 0) {
-            return;
-        }
-        injectXTraceHeader(response);
     }
 
     public static void injectXTraceHeader(ServletResponse response) {
@@ -54,10 +54,5 @@ public class JakartaServletServiceAdvice {
             return in;
         }
         return in.replace("####", "=").replace("....", ",");
-    }
-
-    public static Class<?> getCallDepthKey() {
-        class Key {}
-        return Key.class;
     }
 }


### PR DESCRIPTION
- [JIRA](https://swicloud.atlassian.net/browse/NH-26280)
- remove use of local class because it's identity doesn't change. Hence, it's not a good candidate to guard against re-entrance