### PR TITLE
Enable CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,8 +61,10 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         
-    - name: Build with Gradle and Test
+    - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
       env:
         GP_USERNAME: ${{ secrets.GP_USERNAME }}
         GP_TOKEN: ${{ secrets.GP_TOKEN }}


### PR DESCRIPTION
## Jira

https://swicloud.atlassian.net/browse/ENOPS-3866

## Changes

Enable CodeQL as part of Github Advanced Security trial.  The scan https://github.com/appoptics/solarwinds-apm-java/pull/72/checks?check_run_id=11103453290 did not find alerts, which concurs with Checkmarx not finding any high/medium issues.