### PR TITLE
NH-35062: incorrect ResponseTime metrics format cause wrong requests …

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsInboundMetricsSpanProcessor.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsInboundMetricsSpanProcessor.java
@@ -149,6 +149,9 @@ public class AppOpticsInboundMetricsSpanProcessor implements SpanProcessor {
             if (hasError) {
                 aoSecondaryKey.put("Errors", "true");
                 swoTags.put("sw.is_error", "true");
+
+            } else {
+                swoTags.put("sw.is_error", "false");
             }
 
             final long duration = (spanData.getEndEpochNanos() - spanData.getStartEpochNanos()) / 1000;


### PR DESCRIPTION
…count on service

- [JIRA](https://swicloud.atlassian.net/browse/NH-35062)
- separate reporting to ao and swo into two methods
- refactored a bit