### PR TITLE
NH-4948: ignore agent class for instrumentation

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsIgnoredTypesConfigurer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsIgnoredTypesConfigurer.java
@@ -1,0 +1,15 @@
+package com.appoptics.opentelemetry.extensions;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+@AutoService(IgnoredTypesConfigurer.class)
+public class AppOpticsIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
+    @Override
+    public void configure(IgnoredTypesBuilder builder, ConfigProperties config) {
+        builder.ignoreClass("com.appoptics.ext.");
+        builder.ignoreClass("com.tracelytics.joboe.");
+    }
+}


### PR DESCRIPTION
- [JIRA](https://swicloud.atlassian.net/browse/NH-4948)
This PR supersedes this https://github.com/appoptics/solarwinds-apm-java/pull/23. This is done to ensure that the agent components aren't picked up by auto-instrumentation.