### PR TITLE
NH-34064: upgrade to OTel:1.25.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     dependencies {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.14.0"
         classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
-        classpath "io.opentelemetry.instrumentation:gradle-plugins:1.24.0-alpha"
+        classpath "io.opentelemetry.instrumentation:gradle-plugins:1.25.0-alpha"
     }
 }
 
@@ -23,11 +23,11 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.24.0",
-                opentelemetryJavaagent: "1.24.0",
+                opentelemetry         : "1.25.0",
+                opentelemetryJavaagent: "1.25.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                appopticsCore         : "7.8.3",
+                appopticsCore         : "7.8.4",
                 agent                 : "0.15.3", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]


### PR DESCRIPTION
[JIRA](https://swicloud.atlassian.net/browse/NH-34064)

This OTel release comes with bug fix for this [issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8105). Also upgrade to `joboe:7.8.4` which has a fix for deadlock bug that manifests when our sampler is replaced.