### PR TITLE
NH-35816: support OTLP exporter

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsContextPropagatorProvider.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsContextPropagatorProvider.java
@@ -5,6 +5,8 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
 
+import static com.appoptics.opentelemetry.extensions.initialize.config.ConfigConstants.COMPONENT_NAME;
+
 @AutoService(ConfigurablePropagatorProvider.class)
 public class AppOpticsContextPropagatorProvider implements ConfigurablePropagatorProvider {
 
@@ -15,6 +17,6 @@ public class AppOpticsContextPropagatorProvider implements ConfigurablePropagato
 
     @Override
     public String getName() {
-        return "appoptics";
+        return COMPONENT_NAME;
     }
 }

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsPropertiesSupplier.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsPropertiesSupplier.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.appoptics.opentelemetry.extensions.initialize.OtelAutoConfigurationCustomizerProviderImpl.isAgentEnabled;
+import static com.appoptics.opentelemetry.extensions.initialize.config.ConfigConstants.COMPONENT_NAME;
 
 /**
  * Provide various default properties when running OT agent with AO SPI implementations
@@ -15,9 +16,9 @@ public class AppOpticsPropertiesSupplier implements Supplier<Map<String, String>
 
     static {
         if (isAgentEnabled()) {
-            PROPERTIES.put("otel.traces.exporter", "appoptics");
+            PROPERTIES.put("otel.traces.exporter", COMPONENT_NAME);
             PROPERTIES.put("otel.metrics.exporter", "none");
-            PROPERTIES.put("otel.propagators", "tracecontext,baggage,appoptics");
+            PROPERTIES.put("otel.propagators", String.format("tracecontext,baggage,%s", COMPONENT_NAME));
         } else {
             PROPERTIES.put("otel.javaagent.enabled", "false");
         }

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporterProvider.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsSpanExporterProvider.java
@@ -8,6 +8,8 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 import javax.annotation.Nonnull;
 
+import static com.appoptics.opentelemetry.extensions.initialize.config.ConfigConstants.COMPONENT_NAME;
+
 @AutoService(ConfigurableSpanExporterProvider.class)
 public class AppOpticsSpanExporterProvider implements ConfigurableSpanExporterProvider {
     @Override
@@ -17,6 +19,6 @@ public class AppOpticsSpanExporterProvider implements ConfigurableSpanExporterPr
 
     @Override
     public String getName() {
-        return "appoptics";
+        return COMPONENT_NAME;
     }
 }

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/config/ConfigConstants.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/config/ConfigConstants.java
@@ -7,4 +7,6 @@ public final class ConfigConstants {
     public static final String CONFIG_PREFIX = "sw.apm";
     public static final String SYS_PROPERTY_SERVICE_KEY = CONFIG_PREFIX + ".service.key";
     public static final String SYS_PROPERTY_CONFIG_FILE = CONFIG_PREFIX + ".config.file";
+
+    public static final String COMPONENT_NAME = "solarwinds";
 }


### PR DESCRIPTION
[JIRA](https://swicloud.atlassian.net/browse/NH-35816)
- change custom components' name from `appoptics` to `solarwinds`

OTLP exporter, can be added following the instructions [here](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exporters). OTLP exporter has it's own config like `endpoint`(`-Dotel.exporter.otlp.endpoint` or `OTEL_EXPORTER_OTLP_ENDPOINT`) that needs to be set as well.