### PR TITLE
bug fix remove statement reference from map on exit

### DIFF
--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/QueryArgsCollector.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/QueryArgsCollector.java
@@ -40,6 +40,7 @@ public class QueryArgsCollector {
                 span.setAttribute(AoPreparedStatementInstrumentation.QueryArgsAttributeKey.KEY, queryArgs);
                 argsMap.clear();
             }
+            instrumentationStore.computeIfPresent(statement, (__, ___) -> null);
         }
     }
 }


### PR DESCRIPTION
This change is a response to [this](https://swicloud.atlassian.net/browse/NH-43140) bug report. Although the code path is no longer being executed as a result of this https://github.com/solarwinds/apm-java/pull/102 , it's prudent to make this change now since this code path is probably going to be reenable in the future.