### PR TITLE
NH-42687: investigate missing database span attribute for MrQ

### DIFF
--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoPreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoPreparedStatementInstrumentation.java
@@ -1,7 +1,6 @@
 package com.appoptics.opentelemetry.instrumentation;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
@@ -9,7 +8,6 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import java.sql.PreparedStatement;
-import java.sql.Statement;
 import java.util.List;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
@@ -50,19 +48,7 @@ public class AoPreparedStatementInstrumentation implements TypeInstrumentation {
                 @Advice.This PreparedStatement statement,
                 @Advice.Argument(value = 0, readOnly = true) int index,
                 @Advice.Argument(value = 1, readOnly = true) Object value) {
-            // Connection#getMetaData() may execute a Statement or PreparedStatement to retrieve DB info
-            // this happens before the DB CLIENT span is started (and put in the current context), so this
-            // instrumentation runs again and the shouldStartSpan() check always returns true - and so on
-            // until we get a StackOverflowError
-            // using CallDepth prevents this, because this check happens before Connection#getMetadata()
-            // is called - the first recursive Statement call is just skipped and we do not create a span
-            // for it
-            if (CallDepth.forClass(Statement.class).getAndIncrement() != 0) { //only report back when depth is one to avoid duplications
-                CallDepth.forClass(Statement.class).decrementAndGet();
-                return;
-            }
             QueryArgsCollector.collect(statement, currentContext(), index, value);
-            CallDepth.forClass(Statement.class).decrementAndGet(); // do not want to interfere with the Otel's instrumentation
         }
 
         @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -88,15 +74,8 @@ public class AoPreparedStatementInstrumentation implements TypeInstrumentation {
         public static void onExit(
                 @Advice.This PreparedStatement statement,
                 @Advice.Thrown Throwable throwable) {
-            if (CallDepth.forClass(Statement.class).getAndIncrement() != 1) { //only report back when depth is one to avoid duplications
-                // Note that we need to decrement the call depth counter at every branch, otherwise the JDBC instrumentation of the
-                // Otel agent will break.
-                CallDepth.forClass(Statement.class).decrementAndGet();
-                return;
-            }
             QueryArgsCollector.maybeAttach(statement, currentContext());
             StatementTruncator.maybeTruncateStatement(currentContext());
-            CallDepth.forClass(Statement.class).decrementAndGet(); // do not want to interfere with the Otel's instrumentation
         }
     }
 }

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoStatementInstrumentation.java
@@ -7,17 +7,17 @@ package com.appoptics.opentelemetry.instrumentation;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-import java.sql.Statement;
-
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 /**
  * Experimental instrumentation to add back traces to existing OT spans.
@@ -47,16 +47,9 @@ public class AoStatementInstrumentation implements TypeInstrumentation {
     public static class StatementAdvice {
         @Advice.OnMethodEnter
         public static void onEnter(@Advice.Argument(value = 0, readOnly = false) String sql) {
-            if (CallDepth.forClass(Statement.class).getAndIncrement() != 1) { //only report back when depth is one to avoid duplications
-                // Note that we need to decrement the call depth counter at every branch, otherwise the JDBC instrumentation of the
-                // Otel agent will break.
-                CallDepth.forClass(Statement.class).decrementAndGet();
-                return;
-            }
             sql = TraceContextInjector.inject(currentContext(), sql);
             AoStatementTracer.writeStackTraceSpec(currentContext());
             StatementTruncator.maybeTruncateStatement(currentContext());
-            CallDepth.forClass(Statement.class).decrementAndGet(); // do not want to interfere with the Otel's instrumentation
         }
     }
 

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoStatementTracer.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoStatementTracer.java
@@ -10,16 +10,24 @@ import com.tracelytics.util.BackTraceUtil;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public class AoStatementTracer {
+    private static final Map<String, String> LRUCache = new LinkedHashMap<String, String>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+            return size() > 128;
+        }
+    };
 
-  public static void writeStackTraceSpec(Context context) {
-    Span span = Span.fromContext(context);
-
-    if (span.getSpanContext().isSampled()) {
-      String backTraceString = BackTraceUtil.backTraceToString(BackTraceUtil.getBackTrace(1));
-      span.setAttribute(Constants.SW_KEY_PREFIX + "Backtrace", backTraceString);
-      span.setAttribute(Constants.SW_KEY_PREFIX + "Spec", "query");
+    public static void writeStackTraceSpec(Context context) {
+        Span span = Span.fromContext(context);
+        if (span.getSpanContext().isSampled()) {
+            String backTraceString = LRUCache.computeIfAbsent(span.getSpanContext().getSpanId(), (__) -> BackTraceUtil.backTraceToString(BackTraceUtil.getBackTrace(1)));
+            span.setAttribute(Constants.SW_KEY_PREFIX + "Backtrace", backTraceString);
+            span.setAttribute(Constants.SW_KEY_PREFIX + "Spec", "query");
+        }
     }
-  }
 }
 

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/StatementTruncator.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/StatementTruncator.java
@@ -3,14 +3,13 @@ package com.appoptics.opentelemetry.instrumentation;
 import com.tracelytics.joboe.config.ConfigManager;
 import com.tracelytics.joboe.config.ConfigProperty;
 import com.tracelytics.logging.Logger;
+import com.tracelytics.logging.LoggerFactory;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import com.tracelytics.logging.LoggerFactory;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 
@@ -32,8 +31,8 @@ public class StatementTruncator {
                 Method getAttribute = span.getClass().getDeclaredMethod("getAttribute", AttributeKey.class);
                 getAttribute.setAccessible(true);
                 sql = (String) getAttribute.invoke(span, SemanticAttributes.DB_STATEMENT);
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-                logger.debug("Cannot execute method getAttribute: " + e);
+            } catch (Throwable throwable) {
+                logger.debug("Cannot execute method getAttribute: " + throwable);
             }
             if (sql == null) {
                 return;


### PR DESCRIPTION
This PR removes the use of calldepth. Use of calldepth provides a potential point of contention with upstream instrumentation as upstream uses the same key to manage it's call stack to prevent stack overflow. 

Added some code to ensure the instrumentation code is idempotent, thereby not requiring the use of calldepth. Also, changed the caught exception, in the block where try to use reflection to mutate the span, to something more general in case something is escaping the catch block.

An LRUCache is added to cache backtrace in the event there's reentrance for the same span id. The cache is limited to 128 entries. So the memory footprint will remain low.