### PR TITLE
NH-31132: Skip null schemes…

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/transaction/NamingScheme.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/transaction/NamingScheme.java
@@ -21,10 +21,15 @@ public abstract class NamingScheme {
 
         for (int index = schemes.size() - 1; index > -1; index--) {
             TransactionNamingScheme scheme = schemes.get(index);
+            if (scheme == null) {
+                logger.debug("Null scheme was encountered. Ensure you don't have any trailing commas");
+                continue;
+            }
+
             if (scheme.getDelimiter() != null && scheme.getAttributes() != null) {
                 head = new SpanAttributeNamingScheme(head, scheme.getDelimiter(), scheme.getAttributes());
             } else {
-                logger.warn("Configured scheme is missing required fields. Hence, scheme has no effect");
+                logger.warn(String.format("Configured scheme(%s) is missing required fields. Hence, scheme has no effect", scheme.getScheme()));
             }
         }
 


### PR DESCRIPTION
[NH-31132](https://swicloud.atlassian.net/browse/NH-31132) Null scheme can be potentially included in the deserialized schemes list by Gson when there's a trailing comma at the end of the `JSON` array. This is a limitation of Gson and it seems like there's no simple way to configure Gson to take care of it itself. 

[NH-31132]: https://swicloud.atlassian.net/browse/NH-31132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ