### PR TITLE
NH-39116: HostID Cloud VM retrieval might be instrumented?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
                 opentelemetryJavaagent: "1.26.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                appopticsCore         : "7.8.11",
+                appopticsCore         : "7.8.12",
                 agent                 : "0.17.0-alpha", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]


### PR DESCRIPTION
- [NH-39116](https://swicloud.atlassian.net/browse/NH-31132)
- upgrade to `joboe:7.8.12`

[NH-39116]: https://swicloud.atlassian.net/browse/NH-39116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ