### PR TITLE
NH-54989: Upgrade to upstream agent:v1.29.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     dependencies {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.14.0"
         classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
-        classpath "io.opentelemetry.instrumentation:gradle-plugins:1.26.0-alpha"
+        classpath "io.opentelemetry.instrumentation:gradle-plugins:1.29.0-alpha"
     }
 }
 
@@ -23,8 +23,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.26.0",
-                opentelemetryJavaagent: "1.26.0",
+                opentelemetry         : "1.29.0",
+                opentelemetryJavaagent: "1.29.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
                 appopticsCore         : "7.8.15",

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetry}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:${versions.opentelemetryJavaagentAlpha}")
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
@@ -31,7 +31,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetry}")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:${versions.opentelemetryJavaagentAlpha}")
 

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizer.java
@@ -1,0 +1,20 @@
+package com.appoptics.opentelemetry.extensions.initialize;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+
+import java.util.function.BiFunction;
+
+public class AutoConfiguredResourceCustomizer implements BiFunction<Resource, ConfigProperties, Resource> {
+    private static Resource resource;
+
+    @Override
+    public Resource apply(Resource resource, ConfigProperties configProperties) {
+        AutoConfiguredResourceCustomizer.resource = resource;
+        return resource;
+    }
+
+    public static Resource getResource() {
+        return resource;
+    }
+}

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/OtelAutoConfigurationCustomizerProviderImpl.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/OtelAutoConfigurationCustomizerProviderImpl.java
@@ -49,7 +49,8 @@ public class OtelAutoConfigurationCustomizerProviderImpl implements AutoConfigur
     @Override
     public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
         autoConfiguration.addPropertiesSupplier(new AppOpticsPropertiesSupplier())
-                .addTracerProviderCustomizer(new AppOpticsTracerProviderCustomizer());
+                .addTracerProviderCustomizer(new AppOpticsTracerProviderCustomizer())
+                .addResourceCustomizer(new AutoConfiguredResourceCustomizer());
     }
 
     @Override

--- a/custom/src/test/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizerTest.java
+++ b/custom/src/test/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizerTest.java
@@ -1,0 +1,31 @@
+package com.appoptics.opentelemetry.extensions.initialize;
+
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class AutoConfiguredResourceCustomizerTest {
+
+    @InjectMocks
+    private AutoConfiguredResourceCustomizer tested;
+
+    @Mock
+    private Resource resourceMock;
+
+    @Test
+    void verifyThatAutoConfiguredResourceIsCached(){
+        tested.apply(resourceMock, DefaultConfigProperties.create(Collections.emptyMap()));
+
+        assertNotNull(AutoConfiguredResourceCustomizer.getResource());
+    }
+
+}


### PR DESCRIPTION
- [NH-54989](https://swicloud.atlassian.net/browse/NH-54989)

This PR upgrades to upstream v1.29.0. The upstream removed API for accessing the configured `Resource` via the autoconfigured sdk. Added a `AutoConfiguredResourceCustomizer` to cache the configure `Resource` and provide access to it to other part of the code that needs.

[NH-54989]: https://swicloud.atlassian.net/browse/NH-54989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ