### PR TITLE
NH-37445: Add Live reload for agent configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
                 opentelemetryJavaagent: "1.29.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                appopticsCore         : "7.8.15",
+                appopticsCore         : "7.8.16",
                 agent                 : "0.17.0", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/TransactionNameManager.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/TransactionNameManager.java
@@ -45,17 +45,11 @@ public class TransactionNameManager {
     private static boolean limitExceeded;
     private static int maxNameCount = DEFAULT_MAX_NAME_COUNT;
 
-    private static final boolean domainPrefixedTransactionName;
-
     private static NamingScheme namingScheme = new DefaultNamingScheme(null);
 
     static {
         customTransactionNamePattern = getTransactionNamePattern();
         addNameCountChangeListener();
-
-        Boolean domainPrefixedTransactionNameObject = (Boolean) ConfigManager.getConfig(
-                ConfigProperty.AGENT_DOMAIN_PREFIXED_TRANSACTION_NAME);
-        domainPrefixedTransactionName = domainPrefixedTransactionNameObject != null && domainPrefixedTransactionNameObject; //only set it to true if the flag present and is set to true
     }
 
     private TransactionNameManager() { //forbid instantiation
@@ -112,6 +106,7 @@ public class TransactionNameManager {
     public static String getTransactionName(SpanData spanData) {
         String transactionName = buildTransactionName(spanData);
         if (transactionName != null) {
+            Boolean domainPrefixedTransactionName = ConfigManager.getConfigOptional(ConfigProperty.AGENT_DOMAIN_PREFIXED_TRANSACTION_NAME, false);
             if (domainPrefixedTransactionName) {
                 transactionName = prefixTransactionNameWithDomainName(transactionName, spanData);
             }

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/config/livereload/ConfigurationFileChangeWatcher.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/config/livereload/ConfigurationFileChangeWatcher.java
@@ -1,0 +1,93 @@
+package com.appoptics.opentelemetry.extensions.initialize.config.livereload;
+
+import com.tracelytics.logging.LoggerFactory;
+
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+public final class ConfigurationFileChangeWatcher {
+    private final Path directory;
+
+    private final String filename;
+
+    private final Consumer<Path> fileChangeListener;
+
+    private final WatchService watchService;
+
+    private final ScheduledExecutorService executorService;
+
+    private final long watchPeriod;
+
+    private static ConfigurationFileChangeWatcher INSTANCE;
+
+    private ScheduledFuture<?> scheduledWatch;
+
+
+    private ConfigurationFileChangeWatcher(Path directory,
+                                           String filename,
+                                           long watchPeriod,
+                                           WatchService watchService,
+                                           ScheduledExecutorService executorService, Consumer<Path> fileChangeListener) {
+        this.directory = directory;
+        this.filename = filename;
+        this.watchPeriod = watchPeriod;
+        this.executorService = executorService;
+        this.fileChangeListener = fileChangeListener;
+        this.watchService = watchService;
+    }
+
+    public static void restartWatch(Path directory, String filename, long watchPeriod, WatchService watchService, ScheduledExecutorService scheduledExecutorService, Consumer<Path> fileChangeListener) {
+        if (INSTANCE != null) {
+            INSTANCE.cancelWatch();
+        }
+        INSTANCE = new ConfigurationFileChangeWatcher(directory, filename, watchPeriod, watchService, scheduledExecutorService, fileChangeListener);
+        INSTANCE.startWatch();
+    }
+
+    private void watch() {
+        WatchKey key = watchService.poll();
+        if (key != null) {
+            for (WatchEvent<?> event : key.pollEvents()) {
+                WatchEvent.Kind<?> kind = event.kind();
+                if (kind == OVERFLOW) {
+                    continue;
+                }
+
+                WatchEvent<Path> ev = (WatchEvent<Path>) event;
+                Path filename = ev.context();
+                if (filename.endsWith(this.filename)) {
+                    fileChangeListener.accept(filename);
+                }
+            }
+            boolean valid = key.reset();
+            if (!valid) {
+                LoggerFactory.getLogger().info(String.format("Watch ended for directory(%s) and file(%s) because the directory became inaccessible", directory, filename));
+            }
+        }
+    }
+
+    private void startWatch() {
+        try {
+            directory.register(watchService, ENTRY_MODIFY);
+            scheduledWatch = executorService.scheduleAtFixedRate(this::watch, 0, watchPeriod, TimeUnit.SECONDS);
+            LoggerFactory.getLogger().info(String.format("Started watch for directory(%s), watch period(%d seconds)", directory, watchPeriod));
+        } catch (Exception exception) {
+            LoggerFactory.getLogger().info(String.format("Failed to start watch for directory(%s) and file(%s) due to error - %s", directory, filename, exception));
+        }
+    }
+
+    private void cancelWatch() {
+        if (scheduledWatch != null) {
+            scheduledWatch.cancel(true);
+        }
+    }
+}

--- a/custom/src/test/java/com/appoptics/opentelemetry/extensions/initialize/config/livereload/ConfigurationFileChangeWatcherTest.java
+++ b/custom/src/test/java/com/appoptics/opentelemetry/extensions/initialize/config/livereload/ConfigurationFileChangeWatcherTest.java
@@ -1,0 +1,104 @@
+package com.appoptics.opentelemetry.extensions.initialize.config.livereload;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Collections;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurationFileChangeWatcherTest {
+
+    @Mock
+    private WatchService watchServiceMock;
+
+    @Mock
+    private WatchKey watchKeyMock;
+
+    @Mock
+    private WatchEvent<Path> watchEventMock;
+
+    @Mock
+    private ScheduledExecutorService scheduledExecutorServiceMock;
+
+    @Mock
+    private Consumer<Path> fileChangeListerMock;
+
+    @Mock
+    private ScheduledFuture<?> scheduledFutureMock;
+
+    @Mock
+    private Path dirMock;
+
+    @Captor
+    private ArgumentCaptor<Runnable> runnableArgumentCaptor;
+
+    private final String filename = "file.json";
+
+    private final long watchPeriod = 1;
+
+    @Test
+    void verifyThatOverflowEventsAreIgnored() throws IOException {
+        when(watchServiceMock.poll()).thenReturn(watchKeyMock);
+        when(watchKeyMock.pollEvents()).thenReturn(Collections.singletonList(watchEventMock));
+        when(watchEventMock.kind()).thenAnswer(invocation -> StandardWatchEventKinds.OVERFLOW);
+
+        when(dirMock.register(any(), any())).thenReturn(watchKeyMock);
+        when(scheduledExecutorServiceMock.scheduleAtFixedRate(runnableArgumentCaptor.capture(), anyLong(), anyLong(), any()))
+                .thenAnswer(invocation -> scheduledFutureMock);
+
+        ConfigurationFileChangeWatcher.restartWatch(dirMock,
+                filename,
+                watchPeriod,
+                watchServiceMock,
+                scheduledExecutorServiceMock,
+                fileChangeListerMock);
+
+        runnableArgumentCaptor.getValue().run();
+        verify(watchServiceMock).poll();
+        verify(watchKeyMock).pollEvents();
+        verify(watchEventMock, never()).context();
+    }
+
+    @Test
+    void verifyThatFileChangeListenerIsInvokedWhenFileIsModified() throws IOException {
+        when(watchServiceMock.poll()).thenReturn(watchKeyMock);
+        when(watchKeyMock.pollEvents()).thenReturn(Collections.singletonList(watchEventMock));
+        when(watchEventMock.kind()).thenAnswer(invocation -> StandardWatchEventKinds.ENTRY_MODIFY);
+
+        when(watchEventMock.context()).thenReturn(Paths.get(filename));
+        when(watchKeyMock.reset()).thenReturn(false);
+        when(dirMock.register(any(), any())).thenReturn(watchKeyMock);
+
+        when(scheduledExecutorServiceMock.scheduleAtFixedRate(runnableArgumentCaptor.capture(), anyLong(), anyLong(), any()))
+                .thenAnswer(invocation -> scheduledFutureMock);
+
+        ConfigurationFileChangeWatcher.restartWatch(dirMock,
+                filename,
+                watchPeriod,
+                watchServiceMock,
+                scheduledExecutorServiceMock,
+                fileChangeListerMock);
+
+        runnableArgumentCaptor.getValue().run();
+
+        verify(watchServiceMock).poll();
+        verify(watchKeyMock).pollEvents();
+        verify(watchEventMock).context();
+
+        verify(fileChangeListerMock).accept(any());
+    }
+}

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/StatementTruncator.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/StatementTruncator.java
@@ -16,7 +16,6 @@ import java.lang.reflect.Method;
 public class StatementTruncator {
     private static final Logger logger = LoggerFactory.getLogger();
     public static final int DEFAULT_SQL_MAX_LENGTH = 128 * 1024; //control the max length of the SQL string to avoid BufferOverFlowException
-    private static final int sqlMaxLength = ConfigManager.getConfigOptional(ConfigProperty.AGENT_SQL_QUERY_MAX_LENGTH, DEFAULT_SQL_MAX_LENGTH);
 
     public static void maybeTruncateStatement(Context context) {
         Span span = Span.fromContext(context);
@@ -38,6 +37,7 @@ public class StatementTruncator {
                 return;
             }
 
+            int sqlMaxLength = ConfigManager.getConfigOptional(ConfigProperty.AGENT_SQL_QUERY_MAX_LENGTH, DEFAULT_SQL_MAX_LENGTH);
             if (sql.length() > sqlMaxLength) {
                 sql = sql.substring(0, sqlMaxLength);
                 span.setAttribute(QueryTruncatedAttributeKey.KEY, true);


### PR DESCRIPTION
- [NH-54989](https://swicloud.atlassian.net/browse/NH-37445)

This PR adds live reload for agent configuration file and refactored some configs usages, so they leverage live reload. Although the whole file changes are reloaded, not all changes take effect as re-initialization is not attempted. Only the config map is updated. Code that access configuration by reading the config map will always read the latest config value.

The following config file fields will take effect when modified because they're always read from the map and not cached locally:
- agent.configFileWatchPeriod
- agent.logging
- agent.tracingMode
- agent.sampleRate
- agent.hostnameAlias
- agent.transactionNameSchemes
- agent.internal.transactionSettings
- agent.transactionSettings
- agent.urlSampleRates
- agent.hostnameAlias
- agent.sqlQueryMaxLength
- transaction.prependDomain
- agent.triggerTrace

[NH-54989]: https://swicloud.atlassian.net/browse/NH-54989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ