### PR TITLE
NH-60697: put prepared statement instrumentation behind `agent.sqlTagPrepared` configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ subprojects {
                 opentelemetryJavaagent: "1.29.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                appopticsCore         : "7.8.19",
-                agent                 : "0.17.3", // the custom distro agent version
+                appopticsCore         : "7.8.20",
+                agent                 : "0.17.4-alpha", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]
         versions.appopticsMetrics = "${versions.appopticsCore}" // they share the same version now
@@ -36,8 +36,8 @@ subprojects {
         versions.opentelemetryJavaagentAlpha = "${versions.opentelemetryJavaagent}-alpha"
 
         deps = [
-                bytebuddy           : "net.bytebuddy:byte-buddy-dep:${versions.bytebuddy}",
-                autoservice         : [
+                bytebuddy  : "net.bytebuddy:byte-buddy-dep:${versions.bytebuddy}",
+                autoservice: [
                         "com.google.auto.service:auto-service:${versions.autoservice}",
                         "com.google.auto.service:auto-service-annotations:${versions.autoservice}",
                 ],
@@ -60,9 +60,23 @@ subprojects {
     }
 
     dependencies {
-        testImplementation("org.mockito:mockito-core:3.3.3")
-        testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+        testImplementation project(path: ":bootstrap")
+        testImplementation 'org.mockito:mockito-core:5.3.0'
+        testImplementation 'org.mockito:mockito-junit-jupiter:5.3.0'
+        testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+        testImplementation 'org.mockito:mockito-inline:5.2.0'
+        testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+
+        testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetry}")
+        testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
+        testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:${versions.opentelemetryJavaagentAlpha}")
+
+        testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
+        testImplementation("io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}")
+        testImplementation "com.appoptics.agent.java:core:${versions.appopticsCore}"
+        testImplementation "com.appoptics.agent.java:metrics:${versions.appopticsMetrics}"
     }
 
     checkstyleMain {

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -20,26 +20,6 @@ dependencies {
   annotationProcessor 'org.projectlombok:lombok:1.18.28'
   compileOnly "com.google.auto.service:auto-service-annotations:1.0.1"
   annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-  testImplementation project(path: ":bootstrap")
-
-
-  testImplementation 'org.mockito:mockito-core:5.3.0'
-  testImplementation 'org.mockito:mockito-junit-jupiter:5.3.0'
-  testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
-
-  testImplementation 'org.mockito:mockito-inline:5.2.0'
-  testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
-
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetry}")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:${versions.opentelemetryJavaagentAlpha}")
-
-  testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
-  testImplementation("io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}")
-  testImplementation "com.appoptics.agent.java:core:${versions.appopticsCore}"
-  testImplementation "com.appoptics.agent.java:metrics:${versions.appopticsMetrics}"
-
 }
 
 buildConfig {

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoConnectionInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoConnectionInstrumentation.java
@@ -22,12 +22,13 @@ public class AoConnectionInstrumentation implements TypeInstrumentation {
 
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
-        Boolean sqlTag = ConfigManager.getConfigOptional(ConfigProperty.AGENT_SQL_TAG, false);
-        if (!sqlTag) {
-            return none();
+        Boolean sqlTagPrepared = ConfigManager.getConfigOptional(ConfigProperty.AGENT_SQL_TAG_PREPARED, false);
+        if (sqlTagPrepared) {
+            return named("com.mysql.cj.jdbc.ConnectionImpl") // only inject MySQL JDBC driver
+                    .and(implementsInterface(named("java.sql.Connection")));
         }
-        return named("com.mysql.cj.jdbc.ConnectionImpl") // only inject MySQL JDBC driver
-                .and(implementsInterface(named("java.sql.Connection")));
+
+        return none();
     }
 
     @Override

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoJdbcInstrumentationModule.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoJdbcInstrumentationModule.java
@@ -9,7 +9,7 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
@@ -18,18 +18,14 @@ public class AoJdbcInstrumentationModule extends InstrumentationModule {
     super("sw-jdbc", "solarwinds-jdbc");
   }
 
-
-  //TODO as documented in https://github.com/appoptics/appoptics-opentelemetry-java/issues/5. Expanding this list does NOT work
-//  @Override
-//  protected String[] additionalHelperClassNames() {
-//    return new String [] { AoStatementTracer.class.getName() };
-//  }
-
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return Collections.singletonList(
-            new AoStatementInstrumentation()
-    );
+    List<TypeInstrumentation> typeInstrumentations = new ArrayList<>();
+    typeInstrumentations.add(new AoStatementInstrumentation());
+
+    typeInstrumentations.add(new AoConnectionInstrumentation());
+    typeInstrumentations.add(new AoPreparedStatementInstrumentation());
+    return typeInstrumentations;
   }
 
   @Override

--- a/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/appoptics/opentelemetry/instrumentation/AoStatementInstrumentation.java
@@ -5,6 +5,8 @@
 
 package com.appoptics.opentelemetry.instrumentation;
 
+import com.tracelytics.joboe.config.ConfigManager;
+import com.tracelytics.joboe.config.ConfigProperty;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
@@ -14,10 +16,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 /**
  * Experimental instrumentation to add back traces to existing OT spans.
@@ -33,7 +32,12 @@ public class AoStatementInstrumentation implements TypeInstrumentation {
 
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
-        return implementsInterface(named("java.sql.Statement"));
+        Boolean sqlTag = ConfigManager.getConfigOptional(ConfigProperty.AGENT_SQL_TAG, false);
+        if (sqlTag) {
+            return implementsInterface(named("java.sql.Statement"));
+        }
+
+        return none();
     }
 
     @Override

--- a/instrumentation/jdbc/src/test/java/com/appoptics/opentelemetry/instrumentation/AoConnectionInstrumentationTest.java
+++ b/instrumentation/jdbc/src/test/java/com/appoptics/opentelemetry/instrumentation/AoConnectionInstrumentationTest.java
@@ -1,0 +1,38 @@
+package com.appoptics.opentelemetry.instrumentation;
+
+import com.tracelytics.joboe.config.ConfigManager;
+import com.tracelytics.joboe.config.ConfigProperty;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static net.bytebuddy.matcher.ElementMatchers.none;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class AoConnectionInstrumentationTest {
+    @InjectMocks
+    private AoConnectionInstrumentation tested;
+
+    @Test
+    void returnNoneMatcherWhenSqlTagPreparedIsNotEnabled() {
+        ElementMatcher<TypeDescription> actual = tested.typeMatcher();
+        assertEquals(none(), actual);
+    }
+
+    @Test
+    void returnNonNoneMatcherWhenSqlTagPreparedIsEnabled() {
+        try(MockedStatic<ConfigManager> configManagerMock = mockStatic(ConfigManager.class)){
+            configManagerMock.when(() -> ConfigManager.getConfigOptional(eq(ConfigProperty.AGENT_SQL_TAG_PREPARED), eq(false))).thenReturn(true);
+            ElementMatcher<TypeDescription> actual = tested.typeMatcher();
+            assertNotEquals(none(), actual);
+        }
+    }
+
+}

--- a/instrumentation/jdbc/src/test/java/com/appoptics/opentelemetry/instrumentation/AoPreparedStatementInstrumentationTest.java
+++ b/instrumentation/jdbc/src/test/java/com/appoptics/opentelemetry/instrumentation/AoPreparedStatementInstrumentationTest.java
@@ -1,0 +1,38 @@
+package com.appoptics.opentelemetry.instrumentation;
+
+import com.tracelytics.joboe.config.ConfigManager;
+import com.tracelytics.joboe.config.ConfigProperty;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static net.bytebuddy.matcher.ElementMatchers.none;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class AoPreparedStatementInstrumentationTest {
+    @InjectMocks
+    private AoPreparedStatementInstrumentation tested;
+
+    @Test
+    void returnNoneMatcherWhenSqlTagPreparedIsNotEnabled() {
+        ElementMatcher<TypeDescription> actual = tested.typeMatcher();
+        assertEquals(none(), actual);
+    }
+
+    @Test
+    void returnNonNoneMatcherWhenSqlTagPreparedIsEnabled() {
+        try(MockedStatic<ConfigManager> configManagerMock = mockStatic(ConfigManager.class)){
+            configManagerMock.when(() -> ConfigManager.getConfigOptional(eq(ConfigProperty.AGENT_SQL_TAG_PREPARED), eq(false))).thenReturn(true);
+            ElementMatcher<TypeDescription> actual = tested.typeMatcher();
+            assertNotEquals(none(), actual);
+        }
+    }
+
+}

--- a/instrumentation/jdbc/src/test/java/com/appoptics/opentelemetry/instrumentation/AoStatementInstrumentationTest.java
+++ b/instrumentation/jdbc/src/test/java/com/appoptics/opentelemetry/instrumentation/AoStatementInstrumentationTest.java
@@ -1,0 +1,39 @@
+package com.appoptics.opentelemetry.instrumentation;
+
+import com.tracelytics.joboe.config.ConfigManager;
+import com.tracelytics.joboe.config.ConfigProperty;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static net.bytebuddy.matcher.ElementMatchers.none;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class AoStatementInstrumentationTest {
+    @InjectMocks
+    private AoStatementInstrumentation tested;
+
+    @Test
+    void returnNoneMatcherWhenSqlTagIsNotEnabled() {
+        ElementMatcher<TypeDescription> actual = tested.typeMatcher();
+        assertEquals(none(), actual);
+    }
+
+    @Test
+    void returnNonNoneMatcherWhenSqlTagIsEnabled() {
+        try(MockedStatic<ConfigManager> configManagerMock = mockStatic(ConfigManager.class)){
+            configManagerMock.when(() -> ConfigManager.getConfigOptional(eq(ConfigProperty.AGENT_SQL_TAG), eq(false))).thenReturn(true);
+            ElementMatcher<TypeDescription> actual = tested.typeMatcher();
+            assertNotEquals(none(), actual);
+        }
+    }
+
+}


### PR DESCRIPTION
- add prepared statement instrumentation and move it behind the new `sqlTagPrepared` configuration.
- moved test dependencies into root project removing duplication