### PR TITLE
NH-52514: custom transaction name API should work when request not sampled

### DIFF
--- a/solarwinds-otel-sdk/src/main/java/com/appoptics/api/ext/SolarWindsAgent.java
+++ b/solarwinds-otel-sdk/src/main/java/com/appoptics/api/ext/SolarWindsAgent.java
@@ -37,6 +37,11 @@ public class SolarWindsAgent {
         return true;
     }
 
+    @Deprecated
+    public static boolean waitUntilAgentReady(long timeout, TimeUnit unit) {
+        return waitUntilReady(timeout, unit);
+    }
+
     /**
      * Blocks until agent is ready (established connection with data collector) or timeout expired.
      * <p>
@@ -48,7 +53,7 @@ public class SolarWindsAgent {
      * @param unit    the time unit of the timeout argument
      * @return returns true if the agent is ready
      */
-    public static boolean waitUntilAgentReady(long timeout, TimeUnit unit) {
+    public static boolean waitUntilReady(long timeout, TimeUnit unit) {
         if (agentAttached) {
             return AgentState.waitForReady(timeout, unit);
         }

--- a/solarwinds-otel-sdk/src/main/java/com/appoptics/api/ext/Transaction.java
+++ b/solarwinds-otel-sdk/src/main/java/com/appoptics/api/ext/Transaction.java
@@ -24,7 +24,7 @@ class Transaction {
         Span span = Span.fromContext(context);
         SpanContext spanContext = span.getSpanContext();
         
-        if (!spanContext.isValid() || !spanContext.isSampled() || Strings.isNullOrEmpty(name)) {
+        if (!spanContext.isValid() || Strings.isNullOrEmpty(name)) {
             return false;
         }
         CustomTransactionNameDict.set(spanContext.getTraceId(), name);

--- a/solarwinds-otel-sdk/src/test/java/com/appoptics/api/ext/SolarWindsAgentTest.java
+++ b/solarwinds-otel-sdk/src/test/java/com/appoptics/api/ext/SolarWindsAgentTest.java
@@ -21,7 +21,7 @@ class SolarWindsAgentTest {
     }
 
     @Test
-    void verifyThatWaitUntilAgentReadyReturnsFalseWhenNoop() {
-        assertFalse(SolarWindsAgent.waitUntilAgentReady(0, TimeUnit.MILLISECONDS));
+    void verifyThatWaitUntilReadyReturnsFalseWhenNoop() {
+        assertFalse(SolarWindsAgent.waitUntilReady(0, TimeUnit.MILLISECONDS));
     }
 }


### PR DESCRIPTION
- remove not sampled guard
- deprecate `waitUntilAgentReady` and add `waitUntilReady`