### PR TITLE
NH-55343: Stop Leaking service key via `process.command_args` resource attribute

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizer.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizer.java
@@ -2,8 +2,12 @@ package com.appoptics.opentelemetry.extensions.initialize;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 
+import java.util.List;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 public class AutoConfiguredResourceCustomizer implements BiFunction<Resource, ConfigProperties, Resource> {
     private static Resource resource;
@@ -11,7 +15,22 @@ public class AutoConfiguredResourceCustomizer implements BiFunction<Resource, Co
     @Override
     public Resource apply(Resource resource, ConfigProperties configProperties) {
         AutoConfiguredResourceCustomizer.resource = resource;
-        return resource;
+        String resourceAttribute = resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE);
+        List<String> processArgs = resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS);
+        ResourceBuilder resourceBuilder = resource.toBuilder();
+
+        if (resourceAttribute != null) {
+            resourceBuilder.put(ResourceAttributes.PROCESS_COMMAND_LINE, resourceAttribute.replaceAll("(sw.apm.service.key=)\\S+", "$1****"));
+        }
+
+        if (processArgs != null){
+            List<String> args = processArgs.stream().map(
+                    arg -> arg.replaceAll("(sw.apm.service.key=)\\S+", "$1****")
+            ).collect(Collectors.toList());
+            resourceBuilder.put(ResourceAttributes.PROCESS_COMMAND_ARGS, args);
+        }
+
+        return resourceBuilder.build();
     }
 
     public static Resource getResource() {

--- a/custom/src/test/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizerTest.java
+++ b/custom/src/test/java/com/appoptics/opentelemetry/extensions/initialize/AutoConfiguredResourceCustomizerTest.java
@@ -1,15 +1,19 @@
 package com.appoptics.opentelemetry.extensions.initialize;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
@@ -18,14 +22,46 @@ class AutoConfiguredResourceCustomizerTest {
     @InjectMocks
     private AutoConfiguredResourceCustomizer tested;
 
-    @Mock
-    private Resource resourceMock;
+
+    private final Resource resource = Resource.create(Attributes.builder()
+            .put(ResourceAttributes.PROCESS_COMMAND_LINE, "-Dsw.apm.service.key=token:chubi-token")
+            .put(ResourceAttributes.PROCESS_COMMAND_ARGS, Collections.singletonList("-Dsw.apm.service.key=token:chubi-token"))
+            .build());
 
     @Test
-    void verifyThatAutoConfiguredResourceIsCached(){
-        tested.apply(resourceMock, DefaultConfigProperties.create(Collections.emptyMap()));
-
+    void verifyThatAutoConfiguredResourceIsCached() {
+        tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
         assertNotNull(AutoConfiguredResourceCustomizer.getResource());
+    }
+
+    @Test
+    void verifyThatServiceKeyIsMaskedWhenPresentInProcessCommandLine() {
+        Resource actual = tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
+        assertEquals("-Dsw.apm.service.key=****", actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE));
+    }
+
+
+    @Test
+    void verifyThatProcessCommandLineIsNotModifiedWhenServiceKeyIsNotPresentInProcessCommandLine() {
+        Resource resource = Resource.create(Attributes.builder()
+                .put(ResourceAttributes.PROCESS_COMMAND_LINE, "-Duser.country=US -Duser.language=en").build());
+        Resource actual = tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
+        assertEquals("-Duser.country=US -Duser.language=en", actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE));
+    }
+
+    @Test
+    void verifyThatServiceKeyIsMaskedWhenPresentInProcessCommandArgs() {
+        Resource actual = tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
+        assertEquals("-Dsw.apm.service.key=****", Objects.requireNonNull(actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS)).get(0));
+    }
+
+
+    @Test
+    void verifyThatProcessCommandLineIsNotModifiedWhenServiceKeyIsNotPresentProcessCommandArgs() {
+        Resource resource = Resource.create(Attributes.builder()
+                .put(ResourceAttributes.PROCESS_COMMAND_ARGS, Arrays.asList("-Duser.country=US", "-Duser.language=en")).build());
+        Resource actual = tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
+        assertEquals(Arrays.asList("-Duser.country=US", "-Duser.language=en"), actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS));
     }
 
 }


### PR DESCRIPTION
- mask service key in `process.command_line` and `process.command_args` resource attributes