### PR TITLE
NH-54412: add service name to system property

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/ResourceAttributesToSystemProperties.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/ResourceAttributesToSystemProperties.java
@@ -16,7 +16,7 @@ public class ResourceAttributesToSystemProperties implements AgentListener {
         Resource resource = getResource();
         String serviceName = resource.getAttribute(ResourceAttributes.SERVICE_NAME);
         if (serviceName != null) {
-            System.setProperty("otel.resource." + ResourceAttributes.SERVICE_NAME, serviceName);
+            System.setProperty(ResourceAttributes.SERVICE_NAME.getKey(), serviceName);
         }
     }
 

--- a/custom/src/test/java/com/appoptics/opentelemetry/extensions/ResourceAttributesToSystemPropertiesTest.java
+++ b/custom/src/test/java/com/appoptics/opentelemetry/extensions/ResourceAttributesToSystemPropertiesTest.java
@@ -28,7 +28,7 @@ class ResourceAttributesToSystemPropertiesTest {
             resourceCustomizerMock.when(AutoConfiguredResourceCustomizer::getResource)
                     .thenReturn(Resource.builder().put(ResourceAttributes.SERVICE_NAME, "service").build());
             tested.afterAgent(sdkMock);
-            assertEquals("service", System.getProperty("otel.resource.service.name"));
+            assertEquals("service", System.getProperty("service.name"));
         }
     }
 


### PR DESCRIPTION
This PR adopts [Splunk's](https://github.com/signalfx/splunk-otel-java/blob/main/custom/src/main/java/com/splunk/opentelemetry/resource/ResourceAttributesToSystemProperties.java) approach for making `Resource` attributes available to loggers as system properties for the interim while upstream figures out how to accomplish this.

Sample logger framework pattern to retrieve are
- Log4j2: `resource.service.name=${sys:service.name}`
- Logback: `resource.service.name=${service.name}`