### PR TITLE
Revert "NH-66325: allow public access"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ jobs:
             for region in "${regions[@]}"; do
               aws lambda publish-layer-version \
                           --layer-name $LAYER_NAME \
-                          --principal '*' \
                           --compatible-runtimes "java17" "java11" "java8.al2" "java8" \
                           --compatible-architectures "x86_64" "arm64" \
                           --description "Solarwinds' apm java lambda instrumentation layer, version: $AGENTVERSION" \


### PR DESCRIPTION
Reverts solarwinds-cloud/solarwinds-apm-java#166

it looks like that option is no longer supported.