### PR TITLE
NH-67988: use lambda role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,8 @@ jobs:
     executor: linux
     steps:
       - checkout
-      - aws-cli/install
+      - aws-cli/setup:
+          role_arn: ${AWS_LAMBDA_ROLE}
       - run:
           name: Build agent
           command: ./gradlew clean build -x test
@@ -98,7 +99,6 @@ jobs:
           name: Create lambda layer
           command: |
             regions=(
-            "us-east-1" 
             "ap-northeast-1"
             "ap-northeast-2"
             "ap-south-1"


### PR DESCRIPTION
This PR uses AWS role to get temporary credentials instead of using long lived credentials.