### PR TITLE
NH-68303: upgrade to joboe `8.1.1` 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
                 opentelemetryJavaagent: "1.32.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                appopticsCore         : "8.1.0",
+                appopticsCore         : "8.1.1",
                 agent                 : "1.0.1-alpha", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsInboundMetricsSpanProcessor.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/AppOpticsInboundMetricsSpanProcessor.java
@@ -51,7 +51,10 @@ public class AppOpticsInboundMetricsSpanProcessor implements SpanProcessor {
   }
 
   public static SpanMetricsCollector buildSpanMetricsCollector() {
-    return new SpanMetricsCollector(MEASUREMENT_REPORTER, HISTOGRAM_REPORTER);
+    SpanMetricsCollector spanMetricsCollector =
+        new SpanMetricsCollector(MEASUREMENT_REPORTER, HISTOGRAM_REPORTER);
+    spanMetricsCollector.setMetricFlushListener(TransactionNameManager::clearTransactionNames);
+    return spanMetricsCollector;
   }
 
   @Override

--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/TransactionNameManager.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/TransactionNameManager.java
@@ -343,6 +343,10 @@ public class TransactionNameManager {
   }
 
   public static void clearTransactionNames() {
+    logger.trace(
+        String.format(
+            "Clearing transaction name buffer. Unique transaction count: %d. Note: This log line is used for validation",
+            EXISTING_TRANSACTION_NAMES.size()));
     synchronized (EXISTING_TRANSACTION_NAMES) {
       EXISTING_TRANSACTION_NAMES.clear();
 

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -41,7 +41,8 @@ public class SmokeTest {
                     "Completed operation \\[post init message\\] with Result code \\[OK\\] arg",
                     "hostId:.*[0-9a-z-]+", "Extension attached!","Created collector client  : collector.appoptics.com:443",
                     "trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=(01|00)",
-                    "This log line is used for validation only: service.name: java-apm-smoke-test")
+                    "This log line is used for validation only: service.name: java-apm-smoke-test",
+                    "Clearing transaction name buffer. Unique transaction count: \\d+")
             , new Slf4jLogConsumer(LoggerFactory.getLogger("k6")));
 
 
@@ -208,6 +209,12 @@ public class SmokeTest {
     void assertServiceNameIsSameAsOneInServiceKey() {
         Boolean actual = logStreamAnalyzer.getAnswer().get("This log line is used for validation only: service.name: java-apm-smoke-test");
         assertTrue(actual, "service.name is not updated with name in service key");
+    }
+
+    @Test
+    void assertThatTransactionNameBufferIsCleared() {
+        Boolean actual = logStreamAnalyzer.getAnswer().get("Clearing transaction name buffer. Unique transaction count: \\d+");
+        assertTrue(actual, "Transaction name buffer is not getting cleared on metric flush");
     }
 
 }


### PR DESCRIPTION
This PR upgrades to joboe `8.1.1` and sets metric flush listener for `SpanMetricCollector`. This ensures that transaction cardinality check buffer is reset after metric is flushed to wire.