### PR TITLE
NH-71075: upgrade joboe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
                 opentelemetryJavaagent: "1.32.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                appopticsCore         : "9.1.0",
+                appopticsCore         : "9.1.1",
                 agent                 : "1.0.1-lambda", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]


### PR DESCRIPTION
**Tl;dr**: Upgrade to `joboe:9.1.1`

**Context**:
This upgrade adds the removal of default settings usage in lambda which results in `DROP` decision when settings file is not available.

**Test Plan**:
Refer to https://github.com/solarwinds-cloud/joboe/pull/1635
