### PR TITLE
NH-71327: remove `trace.service.requests` and `trace.service.errors` instruments

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/lambda/InboundMeasurementMetricsGenerator.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/lambda/InboundMeasurementMetricsGenerator.java
@@ -5,7 +5,6 @@ import com.solarwinds.joboe.core.util.HttpUtils;
 import com.solarwinds.joboe.shaded.javax.annotation.Nonnull;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.SpanContext;
@@ -18,21 +17,14 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.SemanticAttributes;
 
 public class InboundMeasurementMetricsGenerator implements SpanProcessor {
-  private LongCounter requestCounter;
-
-  private LongCounter requestErrorCounter;
-
   private LongHistogram responseTime;
 
   private void initializeMeasurements() {
-    if (requestCounter != null) {
+    if (responseTime != null) {
       return;
     }
 
     Meter meter = MeterProvider.getRequestMetricsMeter();
-    requestCounter = meter.counterBuilder("trace.service.requests").build();
-
-    requestErrorCounter = meter.counterBuilder("trace.service.errors").build();
     responseTime =
         meter.histogramBuilder("trace.service.response_time").setUnit("ms").ofLongs().build();
   }
@@ -63,43 +55,26 @@ public class InboundMeasurementMetricsGenerator implements SpanProcessor {
         hasError = HttpUtils.isServerErrorStatusCode(status.intValue());
       }
 
-      AttributesBuilder requestCounterAttr = Attributes.builder();
-      AttributesBuilder requestErrorCounterAttr = Attributes.builder();
       AttributesBuilder responseTimeAttr = Attributes.builder();
-
       if (status != null) {
         String key = "http.status_code";
-        requestCounterAttr.put(key, status);
-        requestErrorCounterAttr.put(key, status);
         responseTimeAttr.put(key, status);
       }
 
       final String method = spanData.getAttributes().get(SemanticAttributes.HTTP_REQUEST_METHOD);
       if (method != null) {
         String methodKey = "http.method";
-
-        requestCounterAttr.put(methodKey, method);
-        requestErrorCounterAttr.put(methodKey, method);
         responseTimeAttr.put(methodKey, method);
       }
 
       String errorKey = "sw.is_error";
       String transactionKey = "sw.transaction";
       if (hasError) {
-        requestCounterAttr.put(errorKey, "true");
-        requestErrorCounterAttr.put(errorKey, "true");
         responseTimeAttr.put(errorKey, "true");
-
-        requestErrorCounter.add(
-            1, requestErrorCounterAttr.put(transactionKey, transactionName).build());
-
       } else {
-        requestCounterAttr.put(errorKey, "false");
-        requestErrorCounterAttr.put(errorKey, "false");
         responseTimeAttr.put(errorKey, "false");
       }
 
-      requestCounter.add(1, requestCounterAttr.put(transactionKey, transactionName).build());
       responseTime.record(duration, responseTimeAttr.put(transactionKey, transactionName).build());
     }
   }


### PR DESCRIPTION
**Tl;dr**: remove derived request metrics

**Context**:
This PR removes derived request metrics `trace.service.requests` and `trace.service.errors` as these can be derived by the backend using the `trace.service.response_time` metric.

**Test Plan**:
Since this is a removal, no test is necessary. It is easily proven by inspection that the code that produces the metrics has been deleted.
