### PR TITLE
NH-71327: Remove E2E test

### DIFF
--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -415,7 +415,6 @@ export default function () {
     const samplecount = (measurement) => check(measurement, {"samplecount": mrs => mrs.value > 0})
     const sample_rate = (measurement) => check(measurement, {"sample_rate": mrs => mrs.value > 0})
     const sample_source = (measurement) => check(measurement, {"sample_source": mrs => mrs.value > 0})
-    const requests = (measurement) => check(measurement, {"requests": mrs => mrs.value > 0})
     const response_time = (measurement) => check(measurement, {"response_time": mrs => mrs.value > 0})
 
     silence(function () {
@@ -436,10 +435,6 @@ export default function () {
 
     silence(function () {
       verify_that_metrics_are_reported("trace.service.sample_source", sample_source)
-    })
-
-    silence(function () {
-      verify_that_metrics_are_reported("trace.service.requests", requests)
     })
 
     silence(function () {

--- a/smoke-tests/src/test/java/com/solarwinds/LambdaTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/LambdaTest.java
@@ -114,16 +114,6 @@ public class LambdaTest {
     double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['sample_source'].passes");
     assertTrue(passes > 1, "Expects a count > 1 ");
   }
-
-  @Test
-  void assertThatRequestsMetricIsReported() throws IOException {
-    String resultJson = new String(
-        Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
-
-    double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['requests'].passes");
-    assertTrue(passes > 1, "Expects a count > 1 ");
-  }
-
   @Test
   void assertThatResponseTimeMetricIsReported() throws IOException {
     String resultJson = new String(


### PR DESCRIPTION
**Tl;dr**: Remove irrelevant E2E test

**Context**:
This PR removes e2e test that's no longer needed since the metric not being recorded anymore. This also fixes the failing test after merge of #183 


**Test Plan**:
See #183 
