### PR TITLE
NH-71355: Remove `trace.service.sample_rate` and `trace.service.sample_source`

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/lambda/TraceDecisionMetricCollector.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/lambda/TraceDecisionMetricCollector.java
@@ -3,33 +3,19 @@ package com.appoptics.opentelemetry.extensions.lambda;
 import static com.solarwinds.joboe.core.util.HostTypeDetector.isLambda;
 
 import com.google.auto.service.AutoService;
-import com.solarwinds.joboe.core.TraceConfig;
 import com.solarwinds.joboe.core.TraceDecisionUtil;
-import com.solarwinds.joboe.core.metrics.measurement.SimpleMeasurementMetricsEntry;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
-import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import java.util.*;
-import lombok.Getter;
+import java.util.LinkedList;
+import java.util.List;
 
 @AutoService(AgentListener.class)
 public class TraceDecisionMetricCollector implements AutoCloseable, AgentListener {
   private final List<ObservableLongGauge> gauges = new LinkedList<>();
 
-  @Getter
-  private final ArrayDeque<SimpleMeasurementMetricsEntry> sampleRateQueue = new ArrayDeque<>();
-
-  @Getter
-  private final ArrayDeque<SimpleMeasurementMetricsEntry> sampleSourceQueue = new ArrayDeque<>();
-
   public void collect(Meter meter) {
-    gauges.add(
-        meter.gaugeBuilder("dummy-gauge").ofLongs().buildWithCallback(this::consumeTraceConfigs));
-
     gauges.add(
         meter
             .gaugeBuilder("trace.service.request_count")
@@ -89,60 +75,6 @@ public class TraceDecisionMetricCollector implements AutoCloseable, AgentListene
                     observableLongMeasurement.record(
                         TraceDecisionUtil.consumeMetricsData(
                             TraceDecisionUtil.MetricType.TRIGGERED_TRACE_COUNT))));
-
-    gauges.add(
-        meter
-            .gaugeBuilder("trace.service.sample_rate")
-            .ofLongs()
-            .buildWithCallback(longMeasurement -> record(longMeasurement, sampleRateQueue)));
-
-    gauges.add(
-        meter
-            .gaugeBuilder("trace.service.sample_source")
-            .ofLongs()
-            .buildWithCallback(longMeasurement -> record(longMeasurement, sampleSourceQueue)));
-  }
-
-  void record(
-      ObservableLongMeasurement longMeasurement, ArrayDeque<SimpleMeasurementMetricsEntry> queue) {
-    while (!queue.isEmpty()) {
-      SimpleMeasurementMetricsEntry measurementMetricsEntry = queue.removeLast();
-      AttributesBuilder attributesBuilder = Attributes.builder();
-      measurementMetricsEntry
-          .getTags()
-          .forEach((key, value) -> attributesBuilder.put(key, (String) value));
-      longMeasurement.record(
-          (Integer) measurementMetricsEntry.getValue(), attributesBuilder.build());
-    }
-  }
-
-  void consumeTraceConfigs(ObservableLongMeasurement ignore) {
-    Map<String, TraceConfig> layerConfigs = TraceDecisionUtil.consumeLastTraceConfigs();
-    Map<Map.Entry<String, Object>, Integer> layerSampleRate = new HashMap<>();
-    Map<Map.Entry<String, Object>, Integer> layerSampleSource = new HashMap<>();
-
-    for (Map.Entry<String, TraceConfig> layerConfig : layerConfigs.entrySet()) {
-      layerSampleRate.put(
-          new AbstractMap.SimpleEntry<>("layer", layerConfig.getKey()),
-          layerConfig.getValue().getSampleRate());
-      layerSampleSource.put(
-          new AbstractMap.SimpleEntry<>("layer", layerConfig.getKey()),
-          layerConfig.getValue().getSampleRateSourceValue());
-    }
-
-    convertToMetricsEntries(layerSampleRate, "SampleRate").forEach(sampleRateQueue::addFirst);
-    convertToMetricsEntries(layerSampleSource, "SampleSource").forEach(sampleSourceQueue::addFirst);
-  }
-
-  private List<SimpleMeasurementMetricsEntry> convertToMetricsEntries(
-      Map<Map.Entry<String, Object>, Integer> data, String keyName) {
-    List<SimpleMeasurementMetricsEntry> entries = new ArrayList<>();
-    for (Map.Entry<Map.Entry<String, Object>, Integer> metricsEntry : data.entrySet()) {
-      Map.Entry<String, Object> singleTag = metricsEntry.getKey();
-      Map<String, Object> tags = Collections.singletonMap(singleTag.getKey(), singleTag.getValue());
-      entries.add(new SimpleMeasurementMetricsEntry(keyName, tags, metricsEntry.getValue()));
-    }
-    return entries;
   }
 
   @Override

--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -413,8 +413,6 @@ export default function () {
     const request_count = (measurement) => check(measurement, {"request_count": mrs => mrs.value > 0})
     const tracecount = (measurement) => check(measurement, {"tracecount": mrs => mrs.value > 0})
     const samplecount = (measurement) => check(measurement, {"samplecount": mrs => mrs.value > 0})
-    const sample_rate = (measurement) => check(measurement, {"sample_rate": mrs => mrs.value > 0})
-    const sample_source = (measurement) => check(measurement, {"sample_source": mrs => mrs.value > 0})
     const response_time = (measurement) => check(measurement, {"response_time": mrs => mrs.value > 0})
 
     silence(function () {
@@ -427,14 +425,6 @@ export default function () {
 
     silence(function () {
       verify_that_metrics_are_reported("trace.service.samplecount", samplecount)
-    })
-
-    silence(function () {
-      verify_that_metrics_are_reported("trace.service.sample_rate", sample_rate)
-    })
-
-    silence(function () {
-      verify_that_metrics_are_reported("trace.service.sample_source", sample_source)
     })
 
     silence(function () {

--- a/smoke-tests/src/test/java/com/solarwinds/LambdaTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/LambdaTest.java
@@ -98,23 +98,6 @@ public class LambdaTest {
   }
 
   @Test
-  void assertThatSampleRateMetricIsReported() throws IOException {
-    String resultJson = new String(
-        Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
-
-    double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['sample_rate'].passes");
-    assertTrue(passes > 1, "Expects a count > 1 ");
-  }
-
-  @Test
-  void assertThatSampleSourceMetricIsReported() throws IOException {
-    String resultJson = new String(
-        Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
-
-    double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['sample_source'].passes");
-    assertTrue(passes > 1, "Expects a count > 1 ");
-  }
-  @Test
   void assertThatResponseTimeMetricIsReported() throws IOException {
     String resultJson = new String(
         Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));


### PR DESCRIPTION
**Tl;dr**: Remove `trace.service.sample_rate` and `trace.service.sample_source` metric as they're deemed optional

**Context**:
This removes the code machinery that generates and records `trace.service.sample_rate` and `trace.service.sample_source` metrics. This decision came about after it was discovered that they're reported only 98%. After a brief discussion, it was determined that they can be remove since they're mostly informational and doesn't have real value.

**Test Plan**:
This is a code deletion no new test plan is needed as there's nothing to test. Will monitor for regression which is very unlikely.
