### PR TITLE
NH-69952: bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
                 appopticsCore         : "9.1.0",
-                agent                 : "1.0.1-alpha", // the custom distro agent version
+                agent                 : "1.2.0", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]
         versions.appopticsMetrics = "${versions.appopticsCore}" // they share the same version now


### PR DESCRIPTION
**Tl;dr**: Release PR

**Context**:
This PR is the first phase in release for `solarwinds-apm-java:1.2.0`. This release features the following changes:
- Updated the default fallback collector endpoint to `apm.collector.na-01.cloud.solarwinds.com` [JIRA](https://swicloud.atlassian.net/browse/NH-67228)
- Removal of resource attribute to system property and adopting upstream implementation for `service.name` attribute in MDC[JIRA](https://swicloud.atlassian.net/browse/NH-64705)
- Addressed netty CVE [JIRA](https://swicloud.atlassian.net/browse/NH-67523)
- Removal of `ThroughIgnoredCount` tracking [JIRA](https://swicloud.atlassian.net/browse/NH-66427)
- Bug fix for metric export cycle transaction name limit not resetting at end of cycle [JIRA](https://swicloud.atlassian.net/browse/NH-68303)
- Upgrade to `joboe:9.1.0` which features a good amount of refactor and size reduction [JIRA](https://swicloud.atlassian.net/browse/NH-69550)
- Code quality improvement [JIRA](https://swicloud.atlassian.net/browse/NH-33951)


**Test Plan**:
We'll rely on the automated release tests.
