### PR TITLE
NH-69952: temporarily allow overwrite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,14 +273,6 @@ jobs:
           command: |
             cat .circleci/version.sh >> $BASH_ENV
       - run:
-          name: Check version doesn't exist
-          command: |
-            # make sure this version hasn't been pushed to prod yet
-            if curl -f -s "https://agent-binaries.cloud.solarwinds.com/apm/java/$AGENTVERSION/solarwinds-apm-config.json" > /dev/null; then
-                echo "This version has been deployed to production already!"
-                exit 1
-            fi
-      - run:
           name: Copy to S3
           command: |
             aws s3 cp agent/build/libs/solarwinds-apm-agent.jar \


### PR DESCRIPTION
**Tl;dr**: Allow S3 file overwrite

**Context**:
Initial release failed because the bucket used for the `VERSION` upload step in the prod job, pointed to the stage bucket. This PR removes this duplicate check to allow the release to complete. This change will be reverted as soon as the release completes.


**Test Plan**:
Please see #186 
