### PR TITLE
NH-71777: Set `OTEL_METRIC_EXPORT_INTERVAL` to 1M seconds

### DIFF
--- a/agent/lambda/swi-handler
+++ b/agent/lambda/swi-handler
@@ -22,6 +22,7 @@ if [ -z "${OTEL_INSTRUMENTATION_AWS_SDK_ENABLED}" ]; then
 fi
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000
+export OTEL_METRIC_EXPORT_INTERVAL=1000000000
 
 CMD="$(echo "$@" | sed 's/-Xshare:on/-Xshare:auto/g')"
 exec $CMD


### PR DESCRIPTION
**Tl;dr**: Set `OTEL_METRIC_EXPORT_INTERVAL` to 1M seconds

**Context**:

This PR sets `OTEL_METRIC_EXPORT_INTERVAL` to 1M seconds ensuring that metrics and traces are only exported at the end of function invocation before returning. This means reliance on force flushing for telemetry export.


**Test Plan**:
We'll manually verify that telemetry are still being exported. This PR will be updated with the result after the fact since new lambda layer will be available after merge.
