### PR TITLE
NH-72222: Fix GRPC context propagation

### DIFF
--- a/custom/src/main/java/com/appoptics/opentelemetry/extensions/SamplingUtil.java
+++ b/custom/src/main/java/com/appoptics/opentelemetry/extensions/SamplingUtil.java
@@ -5,38 +5,28 @@ import com.solarwinds.joboe.core.TraceDecisionUtil;
 import com.solarwinds.joboe.core.XTraceOption;
 import com.solarwinds.joboe.core.XTraceOptions;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.trace.TraceState;
+import java.util.regex.Pattern;
 
 public class SamplingUtil {
   private SamplingUtil() {}
 
   public static final String SW_TRACESTATE_KEY = "sw";
   public static final String SW_XTRACE_OPTIONS_RESP_KEY = "xtrace_options_response";
-  public static final String SW_SPAN_PLACEHOLDER = "SWSpanIdPlaceHolder";
-  public static final String SW_SPAN_PLACEHOLDER_SAMPLED = SW_SPAN_PLACEHOLDER + "-01";
-  public static final String SW_SPAN_PLACEHOLDER_NOT_SAMPLED = SW_SPAN_PLACEHOLDER + "-00";
-
-  public static boolean isValidSwTraceState(TraceState traceState) {
-    return isValidSwTraceState(traceState.get(SW_TRACESTATE_KEY));
-  }
+  static final Pattern SPAN_ID_REGEX = Pattern.compile("[0-9a-fA-F]{16}");
 
   public static boolean isValidSwTraceState(String swVal) {
     if (swVal == null || !swVal.contains("-")) {
       return false;
     }
+
     final String[] swTraceState = swVal.split("-");
     if (swTraceState.length != 2) {
       return false;
     }
 
-    // 16 is the hex length of the Otel trace id
-    return (swTraceState[0].equals(SW_SPAN_PLACEHOLDER) || swTraceState[0].length() == 16)
+    // 16 is the hex length of the Otel span id
+    return (SPAN_ID_REGEX.matcher(swTraceState[0]).matches())
         && (swTraceState[1].equals("00") || swTraceState[1].equals("01"));
-  }
-
-  public static boolean isSwSpanPlaceHolder(TraceState traceState) {
-    String swTracestate = traceState.get(SW_TRACESTATE_KEY);
-    return swTracestate != null && SW_SPAN_PLACEHOLDER.equals(swTracestate.split("-")[0]);
   }
 
   public static void addXtraceOptionsToAttribute(

--- a/custom/src/test/java/com/appoptics/opentelemetry/extensions/SamplingUtilTest.java
+++ b/custom/src/test/java/com/appoptics/opentelemetry/extensions/SamplingUtilTest.java
@@ -3,6 +3,8 @@ package com.appoptics.opentelemetry.extensions;
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.solarwinds.joboe.core.TraceDecision;
@@ -63,5 +65,35 @@ class SamplingUtilTest {
 
     SamplingUtil.addXtraceOptionsToAttribute(traceDecisionMock, xTraceOptions, builder);
     assertEquals("lo:se,check-id:123", builder.build().get(stringKey("SWKeys")));
+  }
+
+  @Test
+  void returnTrueGivenValidSwTraceState() {
+    String swTraceState = "4025843a0f1f35f3-01";
+    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithInvalidFlag() {
+    String swTraceState = "4025843a0f1f35f3-11";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithSpanIdLengthLessThan16() {
+    String swTraceState = "4025843a0f1f35f-01";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithSpanIdLengthGreaterThan16() {
+    String swTraceState = "4025843a0f1f35f33-01";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithInvalidFormat() {
+    String swTraceState = "4025843a0f1f3-5f-01";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
   }
 }

--- a/mvnlocalPub.sh
+++ b/mvnlocalPub.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 # This script exist to enable conveniently building and publishing the artifacts to local maven repo
 date
-./gradlew clean build
+./gradlew spotlessApply clean build
 ./gradlew agent:publishToMavenLocal
 ./gradlew solarwinds-otel-sdk:publishToMavenLocal
 


### PR DESCRIPTION
**Tl;dr**: Remove sampling logic optimization

**Context**:
This PR removes adding of `sw` trace state key at the beginning of a span through `getUpdatedTraceState` method of `SamplingResult` object. This is because upstream eagerly adds the trace state structure into the carrier and for carriers that are of `MultiValueMap` type this introduces multiple entries for the same `tracestate` key causing this GRPC bug.

The solution employed here is to ensures we do not cause this by removing the use of the `tracestate` as way to store local sampling decision. The sampling logic was updated accordingly to compensate for this change.

Though this change ensures we don't cause the issue by using `tracestate` as cache for local trace decision, this issue can still occur when services running GRPC are chained together. We only need three services for this bug to surface again. So in a service call chain of the form `grpc_0 -> grpc_1 -> grpc_2`, the last service's w3c context processing will have two tracestate values. This may not be an issue if we're only interested in the flag.


**Test Plan**:
Manually tested and the result is below.
**Before:**
```
2024-02-08T00:11:02.315069333Z 

carrier: Metadata(traceparent=00-d101dad5cc37534cdb0d81a140911637-81c80e7c00d2d1f6-01,tracestate=sw=SWSpanIdPlaceHolder-01)
after update -> carrier: Metadata(traceparent=00-d101dad5cc37534cdb0d81a140911637-81c80e7c00d2d1f6-01,tracestate=sw=SWSpanIdPlaceHolder-01,tracestate=sw=81c80e7c00d2d1f6-01)
```
**After:**
  ```
2024-02-08T00:17:16.276677048Z

carrier: Metadata(traceparent=00-24bfecc307bf5bdcb05ebce152f7e1c2-4ad7d3a3f43a948f-01)
after update -> carrier: Metadata(traceparent=00-24bfecc307bf5bdcb05ebce152f7e1c2-4ad7d3a3f43a948f-01,tracestate=sw=4ad7d3a3f43a948f-01)  
 ```

[Sample trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/FF8599B9CD9C54A1607B9232F9CD5B18/BD9C053A76984492/details/breakdown?perspective=requests&serviceId=e-1692045885920657408&duration=3600&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
