### PR TITLE
NH-72559: bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
                 joboe                 : "9.1.1",
-                agent                 : "2.0.0-alpha", // the custom distro agent version
+                agent                 : "2.0.0", // the custom distro agent version
                 autoservice           : "1.0.1",
         ]
         versions.opentelemetryAlpha = "${versions.opentelemetry}-alpha"


### PR DESCRIPTION
**Tl;dr**: Release PR

**Context**:
This PR is the first phase in release for `solarwinds-apm-java:2.0.0`. This release features the following changes:

1. Reporting of request counter metrics as otel-metrics in lambda runtime [JIRA.](https://swicloud.atlassian.net/browse/NH-64719)
2. Head-based sampling via reading of settings from file[JIRA.](https://swicloud.atlassian.net/browse/NH-56657)
3. Reporting of inbound metrics as otel-metrics in lambda runtime [JIRA.](https://swicloud.atlassian.net/browse/NH-64022)
4. Removal of fallback to hardcoded default settings when no settings file is available [JIRA.](https://swicloud.atlassian.net/browse/NH-71075)
5. Workaround for two entry creation in lambda runtime [JIRA.](https://swicloud.atlassian.net/browse/NH-71316)
6. Remove reporting of `trace.service.requests` and `trace.service.errors` metrics [JIRA.](https://swicloud.atlassian.net/browse/NH-71327)
7. Remove reporting of `trace.service.sample_rate` and `trace.service.sample_source` metrics [JIRA.](https://swicloud.atlassian.net/browse/NH-71355)
8. Fix propagation of invalid `sw` trace state value [JIRA.](https://swicloud.atlassian.net/browse/NH-72222)
9. Rebrand java code to `solarwinds` instead of `appoptics` [JIRA](https://swicloud.atlassian.net/browse/NH-64290)
10. Integrate lambda support into main branch [JIRA.](https://swicloud.atlassian.net/browse/NH-69642)

**Test Plan**:
We'll rely on the automated release tests.