### PR TITLE
NH-72559: revert group id.

### DIFF
--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -70,7 +70,7 @@ publishing {
             name = 'Librato Open License'
           }
         }
-        groupId = 'com.solarwinds'
+        groupId = 'io.github.appoptics'
         artifactId = "${archivesBaseName}"
         version = "${versions.agent}"
         from components.java


### PR DESCRIPTION
**Tl;dr**: Revert artifact `groud id`

**Context**:
This PR reverts the `group id` for the SDK back `io.github.appoptics` because there is a whole [process](https://central.sonatype.org/register/central-portal/#answer) for registering a `group id` and actually publishing with it.


**Test Plan**:
[Ensured](https://my.na-01.st-ssp.solarwinds.com/136477216875174912/entities/services/e-1662375700522336256/transaction/bG9nZ2luZyBteXNlbGYgb2Zm/traces/requests?duration=1800&sort_by=time&sort_order=descending&heatmap_type=spanDuration) that the sdk still worked with the agent.
