### PR TITLE
NH-72559: update smoke test

### DIFF
--- a/smoke-tests/spring-boot-webmvc/build.gradle
+++ b/smoke-tests/spring-boot-webmvc/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.github.appoptics:solarwinds-otel-sdk:0.15.2")
+    implementation("io.github.appoptics:solarwinds-otel-sdk:2.0.0")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 

--- a/smoke-tests/spring-boot-webmvc/src/main/kotlin/com/solarwinds/webmvc/Controller.kt
+++ b/smoke-tests/spring-boot-webmvc/src/main/kotlin/com/solarwinds/webmvc/Controller.kt
@@ -1,6 +1,6 @@
 package com.solarwinds.webmvc
 
-import com.appoptics.api.ext.SolarWindsAgent
+import com.solarwinds.api.ext.SolarwindsAgent
 import mu.KotlinLogging
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,7 +18,7 @@ class Controller {
 
     @GetMapping("greet/{name}")
     fun greet(@PathVariable name: String): String{
-        SolarWindsAgent.setTransactionName(name)
+        SolarwindsAgent.setTransactionName(name)
         return  "Hello $name\n===================================\n\n"
     }
 

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -161,7 +161,6 @@ public class SmokeTest {
     }
 
     @Test
-    @Disabled
     void assertTransactionNaming() throws IOException {
         String resultJson = new String(Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
         double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['custom transaction name'].passes");


### PR DESCRIPTION
**Tl;dr**: Re-enable transaction naming test

**Context**:
This PR re-enables transaction naming feature test. This was disabled to allow for the release of the new artifact with new package and class names.

**Test Plan**:
Relying on the automated test.