### PR TITLE
NH-75830: publish lambda layer to prod account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ workflows:
           context:
             - AWS_CIRCLE_CI_BUILD
             - solarwinds-cloud-github-read-access
-            - aws-apm-lambda-agent-publish
+            - apm-lambda-publishing-stage
           requires:
             - approve_me-stage
           filters:


### PR DESCRIPTION

**Tl;dr**: publish lambda layer to prod

**Context**:
This PR updates the CircleCI config file to add job for uploading lambda layer to the prod account. This is accomplished by utilizing the same job for publishing to stage and using a new context `apm-lambda-publishing-prod` which contains the role for accessing the prod account. Adds `java21` as a supported runtime.


**Test Plan**:
Relying on the E2E tests.
