### PR TITLE
NH-68635: bump version and use `joboe:v10.0.1`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
               status=0
               aws lambda publish-layer-version \
                           --layer-name $LAYER_NAME \
-                          --compatible-runtimes "java21" "java17" "java11" "java8.al2" "java8" \
+                          --compatible-runtimes "java21" "java17" "java11" "java8.al2" \
                           --compatible-architectures "x86_64" "arm64" \
                           --description "Solarwinds' apm java lambda instrumentation layer, version: $AGENTVERSION" \
                           --region "$region" \

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
                 opentelemetryJavaagent: "2.2.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                joboe                 : "10.0.0",
+                joboe                 : "10.0.1",
                 agent                 : "2.2.0", // the custom distro agent version
                 autoservice           : "1.0.1",
                 caffeine              : "2.9.3",


### PR DESCRIPTION
**Tl;dr**: bump joboe version

**Context**:
 bumps to `joboe:v10.0.1`. remove `java8` from supported runtime since it's amazon linux 1


**Test Plan**:
Did a manual smoke and relying on automated test for the rest.
