### PR TITLE
NH-72576: only set `sw.w3c.tracestate` when vendor info is available

### DIFF
--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsContextPropagator.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsContextPropagator.java
@@ -159,7 +159,11 @@ public class SolarwindsContextPropagator implements TextMapPropagator {
 
     final String traceState = getter.get(carrier, TRACE_STATE);
     if (traceState != null) {
-      context = context.with(TraceStateKey.KEY, traceState);
+      boolean anyMatch =
+          Arrays.stream(traceState.split(",")).anyMatch(info -> !info.startsWith("sw."));
+      if (anyMatch) {
+        context = context.with(TraceStateKey.KEY, traceState);
+      }
     }
     return context;
   }


### PR DESCRIPTION
**Tl;dr**: Fix non-compliant `sw.w3c.tracestate` injection

**Context**:

Adds traversal of `tracestate` to ensure that `sw.w3c.tracestates` is only set when non-sw keys are observed in the state.


**Test Plan**:

Added unit tests and checked that traces from integration test doesn't contain it.
