### PR TITLE
NH-78653: Fix SDK's `java.lang.NoClassDefFoundError`

### DIFF
--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -10,7 +10,6 @@ project.archivesBaseName = 'solarwinds-otel-sdk'
 def relocatePackages = ext.relocatePackages
 
 dependencies {
-  compileOnly project(":custom")
   compileOnly project(":bootstrap")
   compileOnly("io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}")
 
@@ -19,8 +18,7 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:${versions.opentelemetryJavaagentAlpha}")
 
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
-  compileOnly "com.solarwinds.joboe:core:${versions.joboe}"
-  compileOnly "com.solarwinds.joboe:metrics:${versions.joboe}"
+  implementation "com.solarwinds.joboe:logging:${versions.joboe}"
 
   testImplementation project(path: ":bootstrap")
   testImplementation 'org.mockito:mockito-core:5.3.0'

--- a/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/SolarwindsAgent.java
+++ b/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/SolarwindsAgent.java
@@ -1,13 +1,14 @@
 package com.solarwinds.api.ext;
 
+import com.solarwinds.joboe.logging.Logger;
+import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.opentelemetry.core.AgentState;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 public class SolarwindsAgent {
   private SolarwindsAgent() {}
 
-  private static final Logger logger = Logger.getLogger(SolarwindsAgent.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger();
 
   private static boolean agentAttached = false;
 
@@ -18,7 +19,7 @@ public class SolarwindsAgent {
       agentAttached = true;
 
     } catch (ClassNotFoundException | NoClassDefFoundError | NoSuchMethodError e) {
-      logger.warning("The SolarWinds APM Agent is not available. The SDK will be no-op.");
+      logger.warn("The SolarWinds APM Agent is not available. The SDK will be no-op.");
     }
   }
 


### PR DESCRIPTION

**Tl;dr**: Bug fix

**Context**:

use `joboe` logging instead of java logging to avoid `java.lang.NoClassDefFoundError` when agent is not attached.


**Test Plan**:
Locally tested with an instrumented and not instrumented application. The error was present before the fix was applied and nonexistent after.
