### PR TITLE
NH-57065: automagically set otel log exporting configs when enabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
                 opentelemetryJavaagent: "2.4.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
-                joboe                 : "10.0.4",
+                joboe                 : "10.0.5",
                 agent                 : "2.4.0", // the custom distro agent version
                 autoservice           : "1.0.1",
                 caffeine              : "2.9.3",

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/AutoConfigurationCustomizerProviderImpl.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/AutoConfigurationCustomizerProviderImpl.java
@@ -28,6 +28,11 @@ import com.solarwinds.opentelemetry.extensions.SolarwindsTracerProviderCustomize
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
+/**
+ * An implementation of {@link AutoConfigurationCustomizer} which serves as the bootstrap for our
+ * distro. It's the first user class loaded by the upstream agent. We use the opportunity to
+ * bootstrap our configuration via static code.
+ */
 @AutoService({AutoConfigurationCustomizerProvider.class})
 public class AutoConfigurationCustomizerProviderImpl
     implements AutoConfigurationCustomizerProvider {

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
@@ -151,4 +151,49 @@ class ConfigurationLoaderTest {
     assertEquals("test", ServiceKeyUtils.getServiceName(serviceKeyAfter));
     assertEquals("token:test", serviceKeyAfter);
   }
+
+  @Test
+  @ClearSystemProperty(key = "otel.logs.exporter")
+  @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  void verifySettingOtelLogExportSystemVariablesWhenEnabled() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+    configContainer.putByStringValue(
+        ConfigProperty.AGENT_COLLECTOR, "apm.collector.na-02.cloud.solarwinds.com");
+
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "true");
+    ConfigurationLoader.configOtelLogExport(configContainer);
+
+    assertEquals("otlp", System.getProperty("otel.logs.exporter"));
+    assertEquals("grpc", System.getProperty("otel.exporter.otlp.protocol"));
+
+    assertEquals(
+        "https://otel.collector.na-02.cloud.solarwinds.com",
+        System.getProperty("otel.exporter.otlp.logs.endpoint"));
+    assertEquals(
+        "authorization=Bearer token", System.getProperty("otel.exporter.otlp.logs.headers"));
+  }
+
+  @Test
+  @ClearSystemProperty(key = "otel.logs.exporter")
+  @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  void verifyOtelLogExportSystemVariablesAreNotSetWhenDisabled() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "false");
+    configContainer.putByStringValue(
+        ConfigProperty.AGENT_COLLECTOR, "apm.collector.na-02.cloud.solarwinds.com");
+
+    ConfigurationLoader.configOtelLogExport(configContainer);
+
+    assertNull(System.getProperty("otel.logs.exporter"));
+    assertNull(System.getProperty("otel.exporter.otlp.protocol"));
+
+    assertNull(System.getProperty("otel.exporter.otlp.logs.endpoint"));
+    assertNull(System.getProperty("otel.exporter.otlp.logs.headers"));
+  }
 }

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -34,6 +34,12 @@ This directory contains the test machinery code and the machinery is held togeth
 - `SWO_EMAIL`: The swo user email used to get temporary login credentials.
 - `SWO_PWORD`: The swo user password.
 
+## Running the test
+- build docker image for `spring-boot-webmvc` and tag it with `smt:webmvc`
+- set environment variable `LAMBDA=false`
+- From the project root, run `./gradlew test`
+- To execute lambda tests set environment variable `LAMBDA=true`
+
 ## Viewing the data in SWO
 To view test generated data in swo, use service names: `java-apm-smoke-test`, `java-apm-smoke-test-webmvc` and `lambda-e2e`
 

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -241,4 +241,14 @@ public class SmokeTest {
     assertTrue(actual, "sw-jdbc instrumentation is not applied");
   }
 
+
+  @Test
+  void assertThatLogsAreExported() throws IOException {
+    String resultJson = new String(
+        Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
+    double passes = ResultsCollector.read(resultJson,
+        "$.root_group.checks.['logs'].passes");
+    assertTrue(passes > 0, "log export is broken");
+  }
+
 }

--- a/smoke-tests/src/test/java/com/solarwinds/agents/SwoAgentResolver.java
+++ b/smoke-tests/src/test/java/com/solarwinds/agents/SwoAgentResolver.java
@@ -16,15 +16,8 @@
 
 package com.solarwinds.agents;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.Optional;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 
 public class SwoAgentResolver implements AgentResolver {
   private static final String NH_URL = "https://agent-binaries.global.st-ssp.solarwinds.com/apm/java/latest/solarwinds-apm-agent.jar";

--- a/smoke-tests/src/test/java/com/solarwinds/containers/K6Container.java
+++ b/smoke-tests/src/test/java/com/solarwinds/containers/K6Container.java
@@ -59,6 +59,7 @@ public class K6Container {
             .withEnv("SWO_COOKIE", System.getenv("SWO_COOKIE"))
             .withEnv("SWO_XSR_TOKEN", System.getenv("SWO_XSR_TOKEN"))
             .withEnv("LAMBDA", System.getenv("LAMBDA"))
+            .withEnv("SERVICE_NAME", "java-apm-smoke-test")
         .withCommand(
             "run",
             "--summary-export",


### PR DESCRIPTION
**Tl;dr**: export logs via otlp

**Context**:

Add the machinery that makes automagically setting `otel` log export configs possible.


**Test Plan**:

Tested locally and change comes with unit and integration test updates.