### PR TITLE
NH-86006: move endpoint check lower and default to `na-01`

### DIFF
--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
@@ -214,4 +214,19 @@ class ConfigurationLoaderTest {
         "https://otel.collector.na-02.staging.solarwinds.com",
         System.getProperty("otel.exporter.otlp.logs.endpoint"));
   }
+
+  @Test
+  @ClearSystemProperty(key = "otel.logs.exporter")
+  @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  void verifyDefaultEndpointIsUsed() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+    ConfigurationLoader.configOtelLogExport(configContainer);
+
+    assertEquals(
+        "https://otel.collector.na-01.cloud.solarwinds.com",
+        System.getProperty("otel.exporter.otlp.logs.endpoint"));
+  }
 }


### PR DESCRIPTION
**Tl;dr**: use `na-01`

**Context**:

Assume `na-01` when `SW_APM_COLLECTOR` is not specified. This makes the behavior consistent with expectation.


**Test Plan**:
Test services [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600) and [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
