### PR TITLE
NH-85671: upgrade upstream version to `2.5.0` and bump agent version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.38.0",
-                opentelemetryJavaagent: "2.4.0",
+                opentelemetry         : "1.39.0",
+                opentelemetryJavaagent: "2.5.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
                 joboe                 : "10.0.6",
-                agent                 : "2.4.1", // the custom distro agent version
+                agent                 : "2.5.0", // the custom distro agent version
                 autoservice           : "1.0.1",
                 caffeine              : "2.9.3",
                 json : "20231013",


### PR DESCRIPTION

**Tl;dr**: version bump

**Test Plan**:
Test services [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600) and [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
