### PR TITLE
NH-86006: enable profiling for benchmark

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessor.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessor.java
@@ -20,13 +20,8 @@ import static com.solarwinds.opentelemetry.core.Constants.SW_KEY_PREFIX;
 
 import com.solarwinds.joboe.config.ConfigManager;
 import com.solarwinds.joboe.config.ConfigProperty;
-import com.solarwinds.joboe.core.ReporterFactory;
 import com.solarwinds.joboe.core.profiler.Profiler;
 import com.solarwinds.joboe.core.profiler.ProfilerSetting;
-import com.solarwinds.joboe.core.rpc.ClientException;
-import com.solarwinds.joboe.core.rpc.RpcClientManager;
-import com.solarwinds.joboe.logging.Logger;
-import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.Metadata;
 import com.solarwinds.joboe.shaded.javax.annotation.Nonnull;
 import com.solarwinds.opentelemetry.core.Util;
@@ -39,28 +34,10 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 
 /** Span process to perform code profiling */
 public class SolarwindsProfilingSpanProcessor implements SpanProcessor {
-  private static final Logger logger = LoggerFactory.getLogger();
   private static final ProfilerSetting profilerSetting =
       (ProfilerSetting) ConfigManager.getConfig(ConfigProperty.PROFILER);
   private static final boolean PROFILER_ENABLED =
       profilerSetting != null && profilerSetting.isEnabled();
-
-  static {
-    if (PROFILER_ENABLED) {
-      try {
-        Profiler.initialize(
-            profilerSetting,
-            ReporterFactory.getInstance()
-                .createQueuingEventReporter(
-                    RpcClientManager.getClient(RpcClientManager.OperationType.PROFILING)));
-      } catch (ClientException e) {
-        logger.error("Error creating profiling report", e);
-        throw new RuntimeException(e);
-      }
-    } else {
-      logger.info("Profiler is disabled.");
-    }
-  }
 
   @Override
   public void onStart(@Nonnull Context parentContext, ReadWriteSpan span) {

--- a/long-running-test-arch/k8s/deployment-app.yml
+++ b/long-running-test-arch/k8s/deployment-app.yml
@@ -68,6 +68,8 @@ spec:
               value: "petclinic"
             - name: spring_datasource_password
               value: "petclinic"
+            - name: SW_APM_PROFILER_ENABLED
+              value: "true"
 
 ---
 apiVersion: apps/v1
@@ -124,6 +126,8 @@ spec:
               value: "petclinic"
             - name: spring_datasource_password
               value: "petclinic"
+            - name: SW_APM_PROFILER_ENABLED
+              value: "true"
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
**Tl;dr**: update benchmark k8s

**Context**:

Update the long running benchmark k8s to enable profiling, and remove redundant initialization of the profiler because it's initialized [here](https://github.com/solarwinds/apm-java/blob/287ddcb5ae394cefea31312bfe7cfa43e145ac26/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java#L170-L180)


**Test Plan**:
Test services [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600) and [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
