### PR TITLE
NH-86983: make otel log export opt-in only

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
@@ -196,14 +196,14 @@ public class ConfigurationLoader {
 
   static void configOtelLogExport(ConfigContainer container) {
     Boolean exportLog = (Boolean) container.get(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED);
-    String collectorEndpoint = (String) container.get(ConfigProperty.AGENT_COLLECTOR);
-
-    if (exportLog == null || exportLog) {
+    if (exportLog != null && exportLog) {
       String serviceKey = (String) container.get(ConfigProperty.AGENT_SERVICE_KEY);
       String apiKey = ServiceKeyUtils.getApiKey(serviceKey);
 
       String dataCell = "na-01";
       String env = "cloud";
+      String collectorEndpoint = (String) container.get(ConfigProperty.AGENT_COLLECTOR);
+
       if (collectorEndpoint != null) {
         String[] fragments = collectorEndpoint.split("\\.");
         if (fragments.length > 2) {

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
@@ -181,10 +181,9 @@ class ConfigurationLoaderTest {
   @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
   @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
   @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
-  void verifyOtelLogExportSystemVariablesAreNotSetWhenDisabled() throws InvalidConfigException {
+  void verifyOtelLogExportSystemVariablesAreNotSetWhenNotEnabled() throws InvalidConfigException {
     ConfigContainer configContainer = new ConfigContainer();
     configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
-    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "false");
     configContainer.putByStringValue(
         ConfigProperty.AGENT_COLLECTOR, "apm.collector.na-02.cloud.solarwinds.com");
 
@@ -208,6 +207,7 @@ class ConfigurationLoaderTest {
     configContainer.putByStringValue(
         ConfigProperty.AGENT_COLLECTOR, "apm.collector.na-02.staging.solarwinds.com");
 
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "true");
     ConfigurationLoader.configOtelLogExport(configContainer);
 
     assertEquals(
@@ -223,6 +223,8 @@ class ConfigurationLoaderTest {
   void verifyDefaultEndpointIsUsed() throws InvalidConfigException {
     ConfigContainer configContainer = new ConfigContainer();
     configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "true");
     ConfigurationLoader.configOtelLogExport(configContainer);
 
     assertEquals(

--- a/smoke-tests/src/test/java/com/solarwinds/containers/PetClinicRestContainer.java
+++ b/smoke-tests/src/test/java/com/solarwinds/containers/PetClinicRestContainer.java
@@ -85,6 +85,7 @@ public class PetClinicRestContainer implements Container {
               String.format("authorization=Bearer %s", System.getenv("SW_APM_SERVICE_KEY")))
           .withEnv("OTEL_SERVICE_NAME", "lambda-e2e")
           .withEnv("SW_APM_TRANSACTION_NAME", "lambda-test-txn")
+          .withEnv("SW_APM_EXPORT_LOGS_ENABLED", "true")
           .withStartupTimeout(Duration.ofMinutes(5))
           .withCopyFileToContainer(
               MountableFile.forHostPath(agentPath),
@@ -115,6 +116,7 @@ public class PetClinicRestContainer implements Container {
             .withEnv("SW_APM_SQL_TAG", "true")
             .withEnv("SW_APM_SQL_TAG_DATABASES", "postgresql")
             .withEnv("SW_APM_SQL_TAG_PREPARED", "true")
+            .withEnv("SW_APM_EXPORT_LOGS_ENABLED", "true")
             .withEnv("SW_APM_COLLECTOR", System.getenv("SW_APM_COLLECTOR"))
             .withEnv("SW_APM_SERVICE_KEY", String.format("%s:java-apm-smoke-test", System.getenv("SW_APM_SERVICE_KEY")))
             .withStartupTimeout(Duration.ofMinutes(5))


### PR DESCRIPTION
We're making otel log export opt-in only and also updated the test to reflect the current state of things. Now user must explicitly set `SW_APM_EXPORT_LOGS_ENABLED` or its other equivalents to `true` to get this feature enabled.

To check tabs on data generated by tests use below links
Test services [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600) and [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)