### PR TITLE
NH-87394: ensure url is formed when port is appended

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
@@ -205,6 +205,10 @@ public class ConfigurationLoader {
       String collectorEndpoint = (String) container.get(ConfigProperty.AGENT_COLLECTOR);
 
       if (collectorEndpoint != null) {
+        if (collectorEndpoint.contains("appoptics.com")) {
+          return;
+        }
+        collectorEndpoint = collectorEndpoint.split(":")[0];
         String[] fragments = collectorEndpoint.split("\\.");
         if (fragments.length > 2) {
           // This is based on knowledge of the SWO url format where the third name from the left in

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
@@ -220,6 +220,41 @@ class ConfigurationLoaderTest {
   @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
   @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
   @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  void verifyOtelLogExportEndpointIsProperlyFormedWithPort() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+    configContainer.putByStringValue(
+        ConfigProperty.AGENT_COLLECTOR, "otel.collector.na-01.cloud.solarwinds.com:443");
+
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "true");
+    ConfigurationLoader.configOtelLogExport(configContainer);
+
+    assertEquals(
+        "https://otel.collector.na-01.cloud.solarwinds.com",
+        System.getProperty("otel.exporter.otlp.logs.endpoint"));
+  }
+
+  @Test
+  @ClearSystemProperty(key = "otel.logs.exporter")
+  @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  void verifyOtelLogExportEndpointIsNullForAO() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+    configContainer.putByStringValue(ConfigProperty.AGENT_COLLECTOR, "collector.appoptics.com:443");
+
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "true");
+    ConfigurationLoader.configOtelLogExport(configContainer);
+
+    assertNull(System.getProperty("otel.exporter.otlp.logs.endpoint"));
+  }
+
+  @Test
+  @ClearSystemProperty(key = "otel.logs.exporter")
+  @ClearSystemProperty(key = "otel.exporter.otlp.protocol")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.headers")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
   void verifyDefaultEndpointIsUsed() throws InvalidConfigException {
     ConfigContainer configContainer = new ConfigContainer();
     configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");


### PR DESCRIPTION
A customer experienced startup error with our latest release `2.5.0`; this occurred because the code didn't consider that the collector endpoint can be specified with the port number.  This code change addresses this scenario and adds unit test to cover this scenario. We'll not attempt to setup the configuration when the collector endpoint is `appoptics.com`.

Test services [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600) and [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)