### PR TITLE
NH-82783: make signing job explicitly depend on git release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ on:
         default: false
         required: false
         description: Choose whether to do lambda publish
-      sign_release:
-        type: boolean
-        default: false
-        required: false
-        description: Choose whether to create a signed jar
 
 permissions:
   packages: write
@@ -292,7 +287,8 @@ jobs:
           name: arns
 
   sign_release:
-    if: inputs.sign_release
+    needs:
+      - github_release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Making the signing job explicitly dependent on the `github_release` job as we mentioned in #251 . Making it dependent removes the burden on devs/anyone to always remember to run it. We've verified that the signed jar is properly [uploaded](https://github.com/solarwinds/apm-java/releases/tag/v2.5.1).