### PR TITLE
NH-88246: upgrade to upstream `v2.6.0` and minor refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     dependencies {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.14.0"
         classpath "com.github.johnrengelman:shadow:8.1.1"
-        classpath "io.opentelemetry.instrumentation:gradle-plugins:2.5.0-alpha"
+        classpath "io.opentelemetry.instrumentation:gradle-plugins:2.6.0-alpha"
     }
 }
 
@@ -40,12 +40,12 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry         : "1.39.0",
-                opentelemetryJavaagent: "2.5.0",
+                opentelemetry         : "1.40.0",
+                opentelemetryJavaagent: "2.6.0",
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
                 joboe                 : "10.0.11",
-                agent                 : "2.5.1", // the custom distro agent version
+                agent                 : "2.6.0", // the custom distro agent version
                 autoservice           : "1.0.1",
                 caffeine              : "2.9.3",
                 json : "20231013",

--- a/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/TraceDecisionMetricCollector.java
+++ b/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/TraceDecisionMetricCollector.java
@@ -22,12 +22,12 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 @AutoService(AgentListener.class)
 public class TraceDecisionMetricCollector implements AutoCloseable, AgentListener {
-  private final List<ObservableLongGauge> gauges = new LinkedList<>();
+  private final List<ObservableLongGauge> gauges = new ArrayList<>();
 
   public void collect(Meter meter) {
     gauges.add(
@@ -99,5 +99,6 @@ public class TraceDecisionMetricCollector implements AutoCloseable, AgentListene
   @Override
   public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
     collect(MeterProvider.getSamplingMetricsMeter());
+    Runtime.getRuntime().addShutdownHook(new Thread(this::close));
   }
 }


### PR DESCRIPTION
PR upgrades upstream agent and refactors the code to use an `ArrayList` instead of `LinkedList` and closes the gauges before the JVM shuts down. The upgrade doesn't have any visible effect because the renamed [metrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.6.0) are not enabled by default so it seems reasonable to assume there isn't a downstream dependency.