### PR TITLE
CUST-110209: remove joboe logging from SDK 

### DIFF
--- a/gradle/shadow.gradle
+++ b/gradle/shadow.gradle
@@ -17,8 +17,6 @@
 ext.relocatePackages = { shadowJar ->
   // Prevents conflict with other SLF4J instances. Important for premain.
   shadowJar.relocate 'org.slf4j', 'io.opentelemetry.javaagent.slf4j'
-  // rewrite dependencies calling Logger.getLogger
-  shadowJar.relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
 
   // prevents conflict with library instrumentation, since these classes live in the bootstrap class loader
   shadowJar.relocate("io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation") {

--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -34,9 +34,7 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:${versions.opentelemetryJavaagentAlpha}")
 
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
-  implementation "com.solarwinds.joboe:logging:${versions.joboe}"
 
-  testImplementation project(path: ":bootstrap")
   testImplementation 'org.mockito:mockito-core:5.3.0'
   testImplementation 'org.mockito:mockito-junit-jupiter:5.3.0'
 

--- a/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/SolarwindsAgent.java
+++ b/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/SolarwindsAgent.java
@@ -16,15 +16,14 @@
 
 package com.solarwinds.api.ext;
 
-import com.solarwinds.joboe.logging.Logger;
-import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.opentelemetry.core.AgentState;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 public class SolarwindsAgent {
   private SolarwindsAgent() {}
 
-  private static final Logger logger = LoggerFactory.getLogger();
+  private static final Logger logger = Logger.getLogger(SolarwindsAgent.class.getName());
 
   private static boolean agentAttached = false;
 
@@ -35,7 +34,7 @@ public class SolarwindsAgent {
       agentAttached = true;
 
     } catch (ClassNotFoundException | NoClassDefFoundError | NoSuchMethodError e) {
-      logger.warn("The SolarWinds APM Agent is not available. The SDK will be no-op.");
+      logger.warning("The SolarWinds APM Agent is not available. The SDK will be no-op.");
     }
   }
 


### PR DESCRIPTION
This PR removes `joboe:logging` from the SDK. It was added initially to fix `java.lang.NoClassDefFoundError` that occur due to relocation of `JUL(java.util.logger)`. That didn't fix problem, it replaced it with a new one. Now, we've reverted the change and remove the relocation because `JUL` is a JVM API and it's okay to remove the relocation. `JUL` has been part of the JVM since `v1.4` according to the docstring.


**Test Plan**:
Test services data [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600) and [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)