### PR TITLE
NH-89068: use gradle nexus plugin for publishing SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       uses: gradle/actions/setup-gradle@v3
 
     - name: Publish
-      run: ./gradlew publish
+      run: ./gradlew publish closeAndReleaseSonatypeStagingRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # The secrets are for publishing the build artifacts to the Maven Central.

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-group = "com.solarwinds"
-
 buildscript {
     repositories {
         maven {
@@ -32,6 +30,12 @@ buildscript {
         classpath "io.opentelemetry.instrumentation:gradle-plugins:2.6.0-alpha"
     }
 }
+
+plugins{
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+}
+
+group = "com.solarwinds"
 
 subprojects {
   apply plugin: "java"

--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -16,14 +16,17 @@
 
 plugins {
   id("java")
+  id("signing")
   id("maven-publish")
   id("com.github.johnrengelman.shadow")
-  id("signing")
 }
 
 apply from: "$rootDir/gradle/shadow.gradle"
 project.archivesBaseName = 'solarwinds-otel-sdk'
 def relocatePackages = ext.relocatePackages
+
+def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
 
 dependencies {
   compileOnly project(":bootstrap")
@@ -100,9 +103,6 @@ publishing {
   repositories {
     maven {
       name = "OSSRH"
-      def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-      def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-
       url = Boolean.parseBoolean(System.getenv("SNAPSHOT_BUILD")) ? snapshotsRepoUrl : releasesRepoUrl
       credentials {
         username = System.getenv("SONATYPE_USERNAME")
@@ -131,4 +131,16 @@ test {
 
 compileJava {
   options.release.set(8)
+}
+
+nexusPublishing {
+  repositories {
+    sonatype {
+      password = System.getenv("SONATYPE_TOKEN")
+      username = System.getenv("SONATYPE_USERNAME")
+
+      nexusUrl = uri(releasesRepoUrl)
+      snapshotRepositoryUrl = uri(snapshotsRepoUrl)
+    }
+  }
 }


### PR DESCRIPTION
PR adds Gradle nexus [plugin](https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-ossrh) to help automate closing and releasing Solarwinds SDK to Maven Central. This will be tested on the next release of the agent and will make the probability of forgetting to close and release zero. This is safe because the whole release process must be triggered manually and this removes the additional manual steps required.