### PR TITLE
NH-89336: move rl scan to it's own workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Build agent
         run: ./gradlew clean build -x test
 
-      - name: Set agent version env
-        run: |
-          echo "AGENT_VERSION=$(cd agent/build/libs && unzip -p solarwinds-apm-agent.jar META-INF/MANIFEST.MF | grep Implementation-Version | awk '{ print $2 }' | sed 's/[^a-z0-9.-]//g')" >> $GITHUB_ENV
+      - name: Set agent version
+        id: set_version
+        uses: ./.github/actions/version
 
       - name: Copy to S3
         run: |
@@ -90,7 +90,8 @@ jobs:
           aws s3 cp VERSION \
           s3://$STAGE_BUCKET/apm/java/latest/VERSION \
           --acl public-read
-  
+        env:
+          AGENT_VERSION: ${{ steps.set_version.outputs.version }}
 
   build-test-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ on:
         default: false
         required: false
         description: Choose whether to do lambda publish
-      run_rl_scan:
-        type: boolean
-        default: false
-        required: false
-        description: Choose whether to run Reversing lab scan
 
 permissions:
   packages: write
@@ -41,8 +36,6 @@ env:
 jobs:
   maven_release:
     if: inputs.run_maven_release
-    needs:
-      - reversing_lab_scan
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -68,8 +61,6 @@ jobs:
 
   github_release:
     if: inputs.run_github_release
-    needs:
-      - reversing_lab_scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -131,8 +122,6 @@ jobs:
 
   s3-prod-upload:  # this job uploads the jar and default config json to prod s3
     if: inputs.run_s3_upload
-    needs:
-      - reversing_lab_scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -152,9 +141,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_S3_ROLE_ARN_SSP_PROD }}
           aws-region: "us-east-1"
 
-      - name: Set agent version env
-        run: |
-          echo "AGENT_VERSION=$(cd agent/build/libs && unzip -p solarwinds-apm-agent.jar META-INF/MANIFEST.MF | grep Implementation-Version | awk '{ print $2 }' | sed 's/[^a-z0-9.-]//g')" >> $GITHUB_ENV
+      - name: Set agent version
+        id: set_version
+        uses: ./.github/actions/version
 
       - name: Check version doesn't exist
         run: |
@@ -163,6 +152,8 @@ jobs:
               echo "This version has been deployed to production already!"
               exit 1
           fi
+        env:
+          AGENT_VERSION: ${{ steps.set_version.outputs.version }}
 
       - name: Copy to S3
         run: |
@@ -173,6 +164,8 @@ jobs:
           aws s3 cp custom/shared/src/main/resources/solarwinds-apm-config.json \
           s3://$PROD_BUCKET/apm/java/$AGENT_VERSION/solarwinds-apm-config.json \
           --acl public-read
+        env:
+          AGENT_VERSION: ${{ steps.set_version.outputs.version }}
 
       - name: Copy to S3(latest)
         run: |
@@ -192,11 +185,11 @@ jobs:
           aws s3 cp VERSION \
           s3://$PROD_BUCKET/apm/java/latest/VERSION \
           --acl public-read
+        env:
+          AGENT_VERSION: ${{ steps.set_version.outputs.version }}
 
   lambda-publish:
     if: inputs.run_lambda_publish
-    needs:
-      - reversing_lab_scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -393,45 +386,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.set_version.outputs.version }}
-
-  reversing_lab_scan:
-    if: inputs.run_rl_scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Build agent
-        id: build
-        run: |
-          ./gradlew clean build -x test
-          echo "agent_version=$(cd agent/build/libs && unzip -p solarwinds-apm-agent.jar META-INF/MANIFEST.MF | grep Implementation-Version | awk '{ print $2 }' | sed 's/[^a-z0-9.-]//g')" >> $GITHUB_OUTPUT
-
-      - name: Scan Jar
-        uses: reversinglabs/gh-action-rl-scanner-cloud-only@v1
-        with:
-          artifact-to-scan: agent/build/libs/solarwinds-apm-agent.jar
-          rl-verbose: true
-          rl-portal-server: solarwinds
-          rl-portal-org: SolarWinds
-          rl-portal-group: SaaS-Agents-SWO
-          rl-package-url: apm-java/solarwinds-apm-agent@${{ steps.build.outputs.agent_version }}
-        env:
-          RLPORTAL_ACCESS_TOKEN: ${{ secrets.RL_ACCESS_TOKEN }}
-
-      - name: Scan SDK Jar
-        uses: reversinglabs/gh-action-rl-scanner-cloud-only@v1
-        with:
-          artifact-to-scan: solarwinds-otel-sdk/build/libs/solarwinds-otel-sdk.jar
-          rl-verbose: true
-          rl-portal-server: solarwinds
-          rl-portal-org: SolarWinds
-          rl-portal-group: SaaS-Agents-SWO
-          rl-package-url: apm-java/solarwinds-otel-sdk@${{ steps.build.outputs.agent_version }}
-        env:
-          RLPORTAL_ACCESS_TOKEN: ${{ secrets.RL_ACCESS_TOKEN }}

--- a/.github/workflows/rlscan.yml
+++ b/.github/workflows/rlscan.yml
@@ -1,0 +1,91 @@
+name: Reversing Lab Scan
+
+on:
+  schedule:
+    - cron: '0 9 */15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reversing_lab_scan_agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set agent version
+        id: set_version
+        uses: ./.github/actions/version
+
+      - name: Scan Jar
+        uses: reversinglabs/gh-action-rl-scanner-cloud-only@v1
+        with:
+          artifact-to-scan: agent/build/libs/solarwinds-apm-agent.jar
+          rl-verbose: true
+          rl-portal-server: solarwinds
+          rl-portal-org: SolarWinds
+          rl-portal-group: SaaS-Agents-SWO
+          rl-package-url: apm-java/solarwinds-apm-agent@${{ steps.set_version.outputs.version }}
+        env:
+          RLPORTAL_ACCESS_TOKEN: ${{ secrets.RL_ACCESS_TOKEN }}
+
+  reversing_lab_scan_sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set agent version
+        id: set_version
+        uses: ./.github/actions/version
+
+      - name: Scan SDK Jar
+        uses: reversinglabs/gh-action-rl-scanner-cloud-only@v1
+        with:
+          artifact-to-scan: solarwinds-otel-sdk/build/libs/solarwinds-otel-sdk.jar
+          rl-verbose: true
+          rl-portal-server: solarwinds
+          rl-portal-org: SolarWinds
+          rl-portal-group: SaaS-Agents-SWO
+          rl-package-url: apm-java/solarwinds-otel-sdk@${{ steps.set_version.outputs.version }}
+        env:
+          RLPORTAL_ACCESS_TOKEN: ${{ secrets.RL_ACCESS_TOKEN }}
+
+  reversing_lab_scan_lambda:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set agent version
+        id: set_version
+        uses: ./.github/actions/version
+
+      - name: Scan Jar
+        uses: reversinglabs/gh-action-rl-scanner-cloud-only@v1
+        with:
+          artifact-to-scan: agent-lambda/build/libs/solarwinds-apm-agent-lambda.jar
+          rl-verbose: true
+          rl-portal-server: solarwinds
+          rl-portal-org: SolarWinds
+          rl-portal-group: SaaS-Agents-SWO
+          rl-package-url: apm-java/solarwinds-apm-agent-lambda@${{ steps.set_version.outputs.version }}
+        env:
+          RLPORTAL_ACCESS_TOKEN: ${{ secrets.RL_ACCESS_TOKEN }}


### PR DESCRIPTION
Moving the reversing lab scanning to it's own workflow and remove release dependency on it because it can create false-positives. Also, took the liberty to update some version computation code to use the reusable action. The new workflow is set to run twice a month. It looks like the PR needs to be merged before the workflow can be recognized by GitHub.