### PR TITLE
NH-91749: use the new extended span processor

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -207,6 +207,16 @@ jobs:
           cd smoke-tests
           ./gradlew build -x test
 
+      - name: Build webmvc jar
+        run: |
+          cd smoke-tests
+          ./gradlew :spring-boot-webmvc:build
+
+      - name: Build webmvc image
+        run: |
+          cd smoke-tests/spring-boot-webmvc
+          docker image build --tag smt:webmvc .
+
       - name: Docker login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
 

--- a/custom/lambda/build.gradle
+++ b/custom/lambda/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
+  compileOnly project(path: ":bootstrap")
 
   testImplementation project(path: ":custom:shared")
   testImplementation "org.json:json:${versions.json}"

--- a/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/LambdaAgentListener.java
+++ b/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/LambdaAgentListener.java
@@ -23,7 +23,6 @@ import com.google.auto.service.AutoService;
 import com.solarwinds.joboe.logging.Logger;
 import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.SettingsManager;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -42,14 +41,6 @@ public class LambdaAgentListener implements AgentListener {
       SettingsManager.initialize(
           new AwsLambdaSettingsFetcher(new FileSettingsReader("/tmp/solarwinds-apm-settings.json")),
           SamplingConfigProvider.getSamplingConfiguration());
-
-      TransactionNameManager.setRuntimeNameGenerator(
-          spanData ->
-              new TransactionNameManager.TransactionNameResult(
-                  spanData
-                      .getAttributes()
-                      .get(AttributeKey.stringKey(SharedNames.TRANSACTION_NAME_KEY)),
-                  true));
       logger.info("Successfully submitted SolarwindsAPM OpenTelemetry extensions settings");
     } else {
       logger.info("SolarwindsAPM OpenTelemetry extensions is disabled");

--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -552,6 +552,8 @@ function silence(fn) {
 }
 
 export default function () {
+  silence(verify_that_span_data_is_persisted_0)
+
   if (`${__ENV.LAMBDA}` === "true") {
     const request_count = (measurement) => check(measurement, {"request_count": mrs => mrs.value > 0})
     const tracecount = (measurement) => check(measurement, {"tracecount": mrs => mrs.value > 0})
@@ -585,7 +587,6 @@ export default function () {
       })
     silence(verify_logs_export)
     silence(verify_that_specialty_path_is_not_sampled)
-    silence(verify_that_span_data_is_persisted_0)
 
     silence(verify_that_span_data_is_persisted)
     silence(verify_that_trace_is_persisted)

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -72,14 +72,14 @@ public class SmokeTest {
                 .forEach(
                         agent -> {
                             try {
-                                runAppOnce(config, agent);
+                                runAppOnce(agent);
                             } catch (Exception e) {
                                 fail("Unhandled exception in " + config.name(), e);
                             }
                         });
     }
 
-    static void runAppOnce(TestConfig config, Agent agent) throws Exception {
+    static void runAppOnce(Agent agent) throws Exception {
         GenericContainer<?> webMvc = new SpringBootWebMvcContainer(new SwoAgentResolver(), NETWORK, agent).build();
         webMvc.start();
         webMvc.followOutput(logStreamAnalyzer);
@@ -91,11 +91,11 @@ public class SmokeTest {
         GenericContainer<?> postgres = new PostgresContainer(NETWORK).build();
         postgres.start();
 
-        GenericContainer<?> petClinic = new PetClinicRestContainer(new SwoAgentResolver(), NETWORK, agent, namingConventions).build();
+        GenericContainer<?> petClinic = new PetClinicRestContainer(new SwoAgentResolver(), NETWORK, agent).build();
         petClinic.start();
         petClinic.followOutput(logStreamAnalyzer);
 
-        GenericContainer<?> k6 = new K6Container(NETWORK, agent, config, namingConventions).build();
+        GenericContainer<?> k6 = new K6Container(NETWORK, agent, namingConventions).build();
         k6.start();
         k6.followOutput(new Slf4jLogConsumer(LoggerFactory.getLogger("k6")), OutputFrame.OutputType.STDOUT);
 

--- a/smoke-tests/src/test/java/com/solarwinds/containers/K6Container.java
+++ b/smoke-tests/src/test/java/com/solarwinds/containers/K6Container.java
@@ -17,7 +17,6 @@
 package com.solarwinds.containers;
 
 import com.solarwinds.agents.Agent;
-import com.solarwinds.config.TestConfig;
 import com.solarwinds.util.NamingConventions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,14 +34,12 @@ public class K6Container {
   private static final Logger logger = LoggerFactory.getLogger(K6Container.class);
   private final Network network;
   private final Agent agent;
-  private final TestConfig config;
   private final NamingConventions namingConventions;
 
   public K6Container(
-      Network network, Agent agent, TestConfig config, NamingConventions namingConvention) {
+          Network network, Agent agent, NamingConventions namingConvention) {
     this.network = network;
     this.agent = agent;
-    this.config = config;
     this.namingConventions = namingConvention;
   }
 

--- a/smoke-tests/src/test/java/com/solarwinds/containers/PetClinicRestContainer.java
+++ b/smoke-tests/src/test/java/com/solarwinds/containers/PetClinicRestContainer.java
@@ -18,7 +18,7 @@ package com.solarwinds.containers;
 
 import com.solarwinds.agents.Agent;
 import com.solarwinds.agents.AgentResolver;
-import com.solarwinds.util.NamingConventions;
+
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -42,14 +42,12 @@ public class PetClinicRestContainer implements Container {
 
   private final Network network;
   private final Agent agent;
-  private final NamingConventions namingConventions;
 
 
-  public PetClinicRestContainer(AgentResolver agentResolver, Network network, Agent agent, NamingConventions namingConventions) {
+  public PetClinicRestContainer(AgentResolver agentResolver, Network network, Agent agent) {
     this.agentResolver = agentResolver;
     this.network = network;
     this.agent = agent;
-    this.namingConventions = namingConventions;
   }
 
   public GenericContainer<?> build() {
@@ -62,8 +60,6 @@ public class PetClinicRestContainer implements Container {
           .withNetworkAliases("petclinic")
           .withLogConsumer(new Slf4jLogConsumer(logger))
           .withExposedPorts(PETCLINIC_PORT)
-          .withFileSystemBind(namingConventions.localResults(),
-              namingConventions.containerResults())
           .withFileSystemBind("./solarwinds-apm-settings.json", "/tmp/solarwinds-apm-settings.json")
           .withEnv("OTEL_JAVAAGENT_DEBUG", "true")
           .withEnv("SW_APM_SQL_TAG", "true")
@@ -99,7 +95,6 @@ public class PetClinicRestContainer implements Container {
             .withNetworkAliases("petclinic")
             .withLogConsumer(new Slf4jLogConsumer(logger))
             .withExposedPorts(PETCLINIC_PORT)
-            .withFileSystemBind(namingConventions.localResults(), namingConventions.containerResults())
             .withFileSystemBind("./apm-config.json", "/app/apm-config.json")
             .withEnv("SW_APM_CONFIG_FILE", "/app/apm-config.json")
             .withEnv("OTEL_JAVAAGENT_DEBUG", "true")

--- a/smoke-tests/src/test/java/com/solarwinds/util/NamingConvention.java
+++ b/smoke-tests/src/test/java/com/solarwinds/util/NamingConvention.java
@@ -43,24 +43,6 @@ public class NamingConvention {
     return Paths.get(dir, "k6_out_" + agent.getName() + ".json");
   }
 
-  /**
-   * Returns a path to the location of the jfr output file for a given agent run.
-   *
-   * @param agent The agent to get the jfr file path for.
-   */
-  public Path jfrFile(Agent agent) {
-    return Paths.get(dir, "petclinic-" + agent.getName() + ".jfr");
-  }
-
-  /**
-   * Returns the path to the file that contains the startup duration for a given agent run.
-   *
-   * @param agent The agent to get the startup duration for.
-   */
-  public Path startupDurationFile(Agent agent) {
-    return Paths.get(dir, "startup-time-" + agent.getName() + ".txt");
-  }
-
   /** Returns the root path that this naming convention was configured with. */
   public String root() {
     return dir;

--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -36,8 +36,6 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-context:${versions.opentelemetry}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:${versions.opentelemetryJavaagentAlpha}")
 
-  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
-
   testImplementation 'org.mockito:mockito-core:5.3.0'
   testImplementation 'org.mockito:mockito-junit-jupiter:5.3.0'
 

--- a/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/Transaction.java
+++ b/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/Transaction.java
@@ -20,7 +20,6 @@ import com.solarwinds.opentelemetry.core.CustomTransactionNameDict;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
 import java.util.regex.Pattern;
 
 /**
@@ -48,23 +47,7 @@ class Transaction {
       return false;
     }
 
-    CustomTransactionNameDict.set(spanContext.getTraceId(), transformTransactionName(name));
-    LocalRootSpan.fromContext(Context.current())
-        .setAttribute("sw.transaction", transformTransactionName(name));
-
+    CustomTransactionNameDict.set(spanContext.getTraceId(), name);
     return true;
-  }
-
-  private static String transformTransactionName(String transactionName) {
-
-    if (transactionName.length() > 255) {
-      transactionName = transactionName.substring(0, 252) + "...";
-    } else if (transactionName.isEmpty()) {
-      transactionName = " "; // ensure that it at least has 1 character
-    }
-
-    transactionName = REPLACE_PATTERN.matcher(transactionName).replaceAll("_");
-    transactionName = transactionName.toLowerCase();
-    return transactionName;
   }
 }


### PR DESCRIPTION
**Tl;dr**: Set `sw.transaction` with new Span API

**Context**:

 Leverage the new `ExtendedSpanProcessor` to mutate span before it's ended. This API provides a cleaner way to set `sw.transaction` on OTel spans though it's still experimental. Refactored code to remove codes that are now redundant. Also made changes in the test because some stuff don't make sense anymore and added additional test to verify that the Lambda custom transaction name setting works with the new api.

**Test Plan**:
Test services data [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600), [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600) and [3](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)