### PR TITLE
NH-89021: add task to generate `javadoc`

### DIFF
--- a/solarwinds-otel-sdk/SOURCES_DOC_README
+++ b/solarwinds-otel-sdk/SOURCES_DOC_README
@@ -1,1 +1,0 @@
-The -sources.jar and the -javadoc.jar contains nothing.

--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -45,17 +45,18 @@ dependencies {
 }
 
 tasks.register('sourcesJar', Jar) {
-  from('.') {
-    include 'SOURCES_DOC_README'
-  }
+  from sourceSets.main.allJava
   archiveClassifier.set("sources")
 }
 
 tasks.register('javadocJar', Jar) {
-  from('.') {
-    include 'SOURCES_DOC_README'
-  }
+  from generateDoc
   archiveClassifier.set("javadoc")
+}
+
+tasks.register('generateDoc', Javadoc) {
+  source = sourceSets.main.allJava
+  classpath = sourceSets.main.compileClasspath
 }
 
 shadowJar{


### PR DESCRIPTION
**Tl;dr**: publish `javadoc` and `source` jars

**Context**:

Add task to generate `javadoc`. Add publishing of `javadoc` and `source` jars which makes using [javadoc.io](https://www.javadoc.io/) for doc hosting feasible and for navigating and viewing source code respectively.


**Test Plan**:
Test services data [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600), [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600) and [3](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
