### PR TITLE
NH-89068: fix nexus plugin

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -587,4 +587,4 @@ jobs:
           echo "AGENT_VERSION=${{ steps.set_version.outputs.version }}.$GIT_HASH" >> $GITHUB_ENV
 
       - name: Publish
-        run: ./gradlew publish
+        run: ./gradlew publishToSonatype

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       uses: gradle/actions/setup-gradle@v3
 
     - name: Publish
-      run: ./gradlew publish
+      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # The secrets are for publishing the build artifacts to the Maven Central.

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ plugins{
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
-group = "com.solarwinds"
+def swoVersion = property('swo.agent.version')
+group = "io.github.appoptics"
+version = Boolean.parseBoolean(System.getenv("SNAPSHOT_BUILD")) ? "$swoVersion-SNAPSHOT" : swoVersion
 
 subprojects {
   apply plugin: "java"
@@ -49,7 +51,7 @@ subprojects {
                 bytebuddy             : "1.12.10",
                 guava                 : "30.1-jre",
                 joboe                 : "10.0.12",
-                agent                 : "2.8.0", // the custom distro agent version
+                agent                 : swoVersion, // the custom distro agent version
                 autoservice           : "1.0.1",
                 caffeine              : "2.9.3",
                 json : "20231013",
@@ -137,4 +139,16 @@ subprojects {
   java {
     disableAutoTargetJvm()
   }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            password = System.getenv("SONATYPE_TOKEN")
+            username = System.getenv("SONATYPE_USERNAME")
+
+            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ systemProp.org.gradle.internal.repository.initial.backoff=500
 # Project properties provides a central place for shared property among subprojects
 otel.agent.version=2.8.0
 otel.sdk.version=1.42.1
+swo.agent.version=2.8.0

--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -25,9 +25,6 @@ apply from: "$rootDir/gradle/shadow.gradle"
 project.archivesBaseName = 'solarwinds-otel-sdk'
 def relocatePackages = ext.relocatePackages
 
-def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-
 dependencies {
   compileOnly project(":bootstrap")
   compileOnly("io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}")
@@ -87,24 +84,13 @@ publishing {
 
         groupId = 'io.github.appoptics'
         artifactId = "${archivesBaseName}"
-        def sdkVersion = System.getenv("AGENT_VERSION") ?: "2.6.0"
-        version = Boolean.parseBoolean(System.getenv("SNAPSHOT_BUILD")) ? "$sdkVersion-SNAPSHOT" : "${versions.agent}"
+        
+        def snapshotVersion = System.getenv("AGENT_VERSION")
+        version = Boolean.parseBoolean(System.getenv("SNAPSHOT_BUILD")) ? "${snapshotVersion}-SNAPSHOT" : "${versions.agent}"
 
         from components.java
         artifact sourcesJar
         artifact javadocJar
-      }
-    }
-    publishToMavenLocal
-  }
-
-  repositories {
-    maven {
-      name = "OSSRH"
-      url = Boolean.parseBoolean(System.getenv("SNAPSHOT_BUILD")) ? snapshotsRepoUrl : releasesRepoUrl
-      credentials {
-        username = System.getenv("SONATYPE_USERNAME")
-        password = System.getenv("SONATYPE_TOKEN")
       }
     }
   }
@@ -129,16 +115,4 @@ test {
 
 compileJava {
   options.release.set(8)
-}
-
-nexusPublishing {
-  repositories {
-    sonatype {
-      password = System.getenv("SONATYPE_TOKEN")
-      username = System.getenv("SONATYPE_USERNAME")
-
-      nexusUrl = uri(releasesRepoUrl)
-      snapshotRepositoryUrl = uri(snapshotsRepoUrl)
-    }
-  }
 }


### PR DESCRIPTION
**Tl;dr**: fix nexus configuration

**Context**:

Nexus configuration only works on the project's `build.gradle` file and requires the `group id` to match what's registered with upstream repository because that's how it figures out the repository's staging profile id. 
Move `swo` agent version to `gradle.properties`


**Test Plan**:
Test services data [0](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600), [1](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600), [2](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600) and [3](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
