### PR TITLE
NH-93969: remove stored procedure instrumentation

### DIFF
--- a/instrumentation/hibernate/hibernate-4.0/src/test/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v4_0/LoaderInstrumentationTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v4_0/LoaderInstrumentationTest.java
@@ -31,8 +31,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class LoaderInstrumentationTest {
+
   @RegisterExtension
-  public static AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();
+  private static final AgentInstrumentationExtension testing =
+      AgentInstrumentationExtension.create();
 
   private SessionFactory sessionFactory;
 

--- a/instrumentation/hibernate/hibernate-6.0/src/test/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v6_0/DrsaInstrumentationTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/src/test/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v6_0/DrsaInstrumentationTest.java
@@ -37,7 +37,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DrsaInstrumentationTest {
 
   @RegisterExtension
-  public static AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();
+  private static final AgentInstrumentationExtension testing =
+      AgentInstrumentationExtension.create();
 
   private SessionFactory sessionFactory;
 
@@ -93,6 +94,7 @@ class DrsaInstrumentationTest {
 
           session.close();
         });
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(

--- a/instrumentation/jdbc/build.gradle
+++ b/instrumentation/jdbc/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-apply plugin: 'groovy'
 apply from: "$rootDir/gradle/instrumentation.gradle"
+
 
 dependencies {
   compileOnly project(":bootstrap")
@@ -30,22 +30,8 @@ dependencies {
 
   testImplementation project(":instrumentation:jdbc")
   testImplementation project(":instrumentation:instrumentation-shared")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common:${versions.opentelemetryJavaagentAlpha}") {
-    exclude group: 'org.eclipse.jetty', module: 'jetty-server'
-  }
-
-  // mandatory dependencies for using Spock
-  testImplementation "org.apache.groovy:groovy:4.0.1"
-  testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-  testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
 }
 
-test {
-  useJUnitPlatform()
-  testLogging {
-    events "passed", "skipped", "failed"
-  }
-}
 
 compileJava {
   dependsOn(':instrumentation:instrumentation-shared:byteBuddyJava')

--- a/instrumentation/jdbc/src/main/java/com/solarwinds/opentelemetry/instrumentation/JdbcConnectionInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/solarwinds/opentelemetry/instrumentation/JdbcConnectionInstrumentation.java
@@ -24,7 +24,6 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.solarwinds.opentelemetry.instrumentation.jdbc.shared.DbConstraintChecker;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -69,9 +68,7 @@ public class JdbcConnectionInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        nameStartsWith("prepare")
-            .and(takesArgument(0, String.class))
-            // Also include CallableStatement, which is a subtype of PreparedStatement
+        named("prepareStatement")
             .and(returns(implementsInterface(named("java.sql.PreparedStatement")))),
         JdbcConnectionInstrumentation.class.getName() + "$PrepareAdvice");
   }

--- a/testing/agent-for-testing/build.gradle
+++ b/testing/agent-for-testing/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     javaagentLibs project(":custom")
     javaagentLibs project(":custom:shared")
     javaagentLibs project(":testing:agent-test-extension")
-    javaagentLibs project(":testing:agent-test-extension")
     javaagentLibs project(":instrumentation:instrumentation-shared")
     javaagentLibs project(':instrumentation:hibernate:hibernate-shared')
 


### PR DESCRIPTION
**Tl;dr**: exclude stored procedure calls from trace context injection

**Context**:

This change removes injection of trace context into SQL statements that target stored procedures.


**Test Plan**:
sample [trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/98202CC9E4B9EA3AA79C6FC66F63DE27/6792CA386196374A/graph?duration=86400&perspective=requests&serviceId=e-1786116946357092352#event-6BA85A9C966D4318)
