### PR TITLE
NH-97250: upgrade to upstream `v2.10.0`

### DIFF
--- a/agent-lambda/build.gradle
+++ b/agent-lambda/build.gradle
@@ -18,7 +18,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
     id 'maven-publish'
     id 'signing'
 }

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -17,7 +17,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
   id 'maven-publish'
   id 'signing'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     }
     dependencies {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.14.0"
-        classpath "com.github.johnrengelman:shadow:8.1.1"
+        classpath "com.gradleup.shadow:shadow-gradle-plugin:8.3.5"
         classpath "io.opentelemetry.instrumentation:gradle-plugins:${property('otel.agent.version')}-alpha"
     }
 }
@@ -48,7 +48,7 @@ subprojects {
         versions = [
                 opentelemetry         : property('otel.sdk.version'), // property is defined in gradle.properties
                 opentelemetryJavaagent: property('otel.agent.version'),
-                bytebuddy             : "1.12.10",
+                bytebuddy             : "1.15.10",
                 guava                 : "30.1-jre",
                 joboe                 : "10.0.15",
                 agent                 : swoVersion, // the custom distro agent version

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsBootstrapPackagesProvider.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsBootstrapPackagesProvider.java
@@ -25,7 +25,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
  * This adds the Joboe core classes to the list which would always be loaded by the bootstrap
  * classloader, no matter what classloader is used initially. The Otel agent instruments all
  * classloaders and checks the class named to be loaded. It will load the class with the bootstrap
- * classloader if the class mateches any of the prefix in the list above.
+ * classloader if the class matches any of the prefix in the list above.
  */
 @AutoService(BootstrapPackagesConfigurer.class)
 public class SolarwindsBootstrapPackagesProvider implements BootstrapPackagesConfigurer {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ systemProp.org.gradle.internal.repository.max.retries=10
 systemProp.org.gradle.internal.repository.initial.backoff=500
 
 # Project properties provides a central place for shared property among subprojects
-otel.agent.version=2.9.0
-otel.sdk.version=1.43.0
-swo.agent.version=2.9.1
+otel.agent.version=2.10.0
+otel.sdk.version=1.44.1
+swo.agent.version=2.10.0

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -15,7 +15,7 @@
  */
 
 apply plugin: 'java'
-apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.gradleup.shadow'
 apply plugin: 'io.opentelemetry.instrumentation.muzzle-generation'
 apply plugin: 'io.opentelemetry.instrumentation.muzzle-check'
 

--- a/instrumentation/hibernate/hibernate-6.0/src/main/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v6_0/DrsaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-6.0/src/main/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v6_0/DrsaInstrumentation.java
@@ -54,7 +54,6 @@ public class DrsaInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void startMethod(
-        @Advice.This DeferredResultSetAccess drsa,
         @Advice.Local("swoCallDepth") CallDepth callDepth,
         @Advice.Local("swoSqlContext") String swoSql,
         @Advice.Local("swoContext") Context context,

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -54,7 +54,7 @@ public class SmokeTest {
     private static final NamingConventions namingConventions = new NamingConventions();
 
     private static final LogStreamAnalyzer<Slf4jLogConsumer> logStreamAnalyzer = new LogStreamAnalyzer<>(
-            List.of("Transformed (com.solarwinds.ext.*|com.solarwinds.joboe.*)","hostId:.*i-[0-9a-z]+",
+            List.of("hostId:.*i-[0-9a-z]+",
                     "Completed operation \\[post init message\\] with Result code \\[OK\\] arg",
                     "hostId:.*[0-9a-z-]+", "Extension attached!","Created collector client  : collector.appoptics.com:443",
                     "trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=(01|00)",
@@ -181,12 +181,6 @@ public class SmokeTest {
         String resultJson = new String(Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
         double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['custom transaction name'].passes");
         assertTrue(passes > 0, "transaction naming is broken");
-    }
-
-    @Test
-    void assertAgentClassesAreNotInstrumented() {
-        Boolean actual = logStreamAnalyzer.getAnswer().get("Transformed (com.solarwinds.ext.*|com.solarwinds.joboe.*)");
-        assertFalse(actual, "agent classes are instrumented");
     }
 
     @Test

--- a/solarwinds-otel-sdk/build.gradle
+++ b/solarwinds-otel-sdk/build.gradle
@@ -18,7 +18,7 @@ plugins {
   id("java")
   id("signing")
   id("maven-publish")
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
 }
 
 apply from: "$rootDir/gradle/shadow.gradle"

--- a/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/Transaction.java
+++ b/solarwinds-otel-sdk/src/main/java/com/solarwinds/api/ext/Transaction.java
@@ -20,15 +20,12 @@ import com.solarwinds.opentelemetry.core.CustomTransactionNameDict;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import java.util.regex.Pattern;
 
 /**
  * The API to set the custom transaction name for the current trace. It returns false if the current
  * trace is not valid or not sampled.
  */
 class Transaction {
-
-  private static final Pattern REPLACE_PATTERN = Pattern.compile("[^-.:_\\\\/\\w? ]");
 
   /**
    * Set the transaction name of the current trace.

--- a/testing/agent-for-testing/build.gradle
+++ b/testing/agent-for-testing/build.gradle
@@ -17,7 +17,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 apply from: "$rootDir/gradle/shadow.gradle"


### PR DESCRIPTION
Removed test because it's producing a false-positive. Existence of that log line doesn't necessarily mean that the class is being instrumented. For an instrumentation to actually apply to our classes it must be explicitly targeted to the relocation namespace of `com.solarwinds.joboe.*` and we have tests that ensure dependencies are properly relocated to that namespace.