### PR TITLE
NH-98000: export only swo metrics when disabled.

### DIFF
--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/MeterProvider.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/MeterProvider.java
@@ -21,18 +21,18 @@ import io.opentelemetry.api.metrics.Meter;
 
 public class MeterProvider {
 
-  public static final String samplingMeterName = "sw.apm.sampling.metrics";
+  public static final String samplingMeterScopeName = "sw.apm.sampling.metrics";
 
-  public static final String requestMeterName = "sw.apm.request.metrics";
+  public static final String requestMeterScopeName = "sw.apm.request.metrics";
 
   public static Meter getSamplingMetricsMeter() {
-    return GlobalOpenTelemetry.meterBuilder(samplingMeterName)
+    return GlobalOpenTelemetry.meterBuilder(samplingMeterScopeName)
         .setInstrumentationVersion(BuildConfig.SOLARWINDS_AGENT_VERSION)
         .build();
   }
 
   public static Meter getRequestMetricsMeter() {
-    return GlobalOpenTelemetry.meterBuilder(requestMeterName)
+    return GlobalOpenTelemetry.meterBuilder(requestMeterScopeName)
         .setInstrumentationVersion(BuildConfig.SOLARWINDS_AGENT_VERSION)
         .build();
   }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoaderTest.java
@@ -397,13 +397,6 @@ class ConfigurationLoaderTest {
   }
 
   @Test
-  void returnFalseWhenDisabledForMetric() throws InvalidConfigException {
-    ConfigManager.setConfig(ConfigProperty.AGENT_EXPORT_METRICS_ENABLED, false);
-    assertFalse(ConfigurationLoader.shouldUseOtlpForMetrics());
-    ConfigManager.removeConfig(ConfigProperty.AGENT_EXPORT_METRICS_ENABLED);
-  }
-
-  @Test
   void returnEnvironmentVariableEquivalent() {
     assertEquals(
         "OTEL_EXPORTER_OTLP_ENDPOINT",


### PR DESCRIPTION
Filter out non-swo system metrics when metric export is disabled using `SW_APM_EXPORT_METRICS_ENABLED=false`. Note that no metric will be exported at all if it's disabled with `-Dotel.metrics.exporter=none` or other equivalents.