### PR TITLE
NH-98674: address compiler warnings

### DIFF
--- a/buildSrc/src/main/kotlin/solarwinds.instrumentation-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/solarwinds.instrumentation-conventions.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
 
   compileOnly("net.bytebuddy:byte-buddy")
+
+  // Used by byte-buddy but not brought in as a transitive dependency.
+  compileOnly("com.google.code.findbugs:annotations")
   compileOnly("com.google.auto.service:auto-service")
   annotationProcessor("com.google.auto.service:auto-service")
 

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -18,12 +18,14 @@ dependencies {
   compileOnly(project(":bootstrap"))
   compileOnly(project(":custom:shared"))
   compileOnly("com.solarwinds.joboe:core")
-  compileOnly("com.solarwinds.joboe:metrics")
 
   compileOnly("org.projectlombok:lombok")
+  compileOnly("com.solarwinds.joboe:metrics")
   annotationProcessor("org.projectlombok:lombok")
+
+  compileOnly("com.google.auto.service:auto-service")
   annotationProcessor("com.google.auto.service:auto-service")
-  compileOnly("com.google.auto.service:auto-service-annotations")
+  compileOnly("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
 
   compileOnly("io.opentelemetry:opentelemetry-api")
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")

--- a/custom/lambda/build.gradle.kts
+++ b/custom/lambda/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
   compileOnly("com.solarwinds.joboe:sampling")
 
   compileOnly("com.solarwinds.joboe:logging")
+  compileOnly("com.google.auto.service:auto-service")
   annotationProcessor("com.google.auto.service:auto-service")
-  compileOnly("com.google.auto.service:auto-service-annotations")
 
   compileOnly("io.opentelemetry:opentelemetry-api")
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")

--- a/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/PropertiesSupplier.java
+++ b/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/PropertiesSupplier.java
@@ -34,6 +34,7 @@ public class PropertiesSupplier implements Supplier<Map<String, String>> {
     defaultProperties.put(
         "otel.java.experimental.span-stacktrace.filter", SPAN_STACKTRACE_FILTER_CLASS);
     defaultProperties.put("otel.exporter.otlp.protocol", "grpc");
+    defaultProperties.put("otel.semconv-stability.opt-in", "database/dup");
   }
 
   @Override

--- a/custom/shared/build.gradle.kts
+++ b/custom/shared/build.gradle.kts
@@ -24,10 +24,11 @@ dependencies {
 
   compileOnly("com.solarwinds.joboe:config")
   compileOnly("com.solarwinds.joboe:logging")
+  compileOnly("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
 
   compileOnly("com.solarwinds.joboe:sampling")
+  compileOnly("com.google.auto.service:auto-service")
   annotationProcessor("com.google.auto.service:auto-service")
-  compileOnly("com.google.auto.service:auto-service-annotations")
 
   compileOnly("io.opentelemetry:opentelemetry-api")
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGenerator.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGenerator.java
@@ -35,7 +35,7 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.internal.ExtendedSpanProcessor;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
 
 public class InboundMeasurementMetricsGenerator implements ExtendedSpanProcessor {
   private LongHistogram responseTime;
@@ -78,8 +78,7 @@ public class InboundMeasurementMetricsGenerator implements ExtendedSpanProcessor
       final String transactionName = TransactionNameManager.getTransactionName(spanData);
 
       boolean hasError = spanData.getStatus().getStatusCode() == StatusCode.ERROR;
-      final Long status =
-          spanData.getAttributes().get(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE);
+      final Long status = spanData.getAttributes().get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE);
 
       final long duration =
           (spanData.getEndEpochNanos() - spanData.getStartEpochNanos()) / 1_000_000;
@@ -90,7 +89,7 @@ public class InboundMeasurementMetricsGenerator implements ExtendedSpanProcessor
         responseTimeAttr.put(key, status);
       }
 
-      final String method = spanData.getAttributes().get(SemanticAttributes.HTTP_REQUEST_METHOD);
+      final String method = spanData.getAttributes().get(HttpAttributes.HTTP_REQUEST_METHOD);
       if (span.getKind() == SpanKind.SERVER && method != null) {
         String methodKey = "http.method";
         responseTimeAttr.put(methodKey, method);

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/ResourceCustomizer.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/ResourceCustomizer.java
@@ -20,7 +20,8 @@ import com.solarwinds.joboe.logging.LoggerFactory;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
-import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.ServiceAttributes;
+import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -31,12 +32,14 @@ public class ResourceCustomizer implements BiFunction<Resource, ConfigProperties
   @Override
   public Resource apply(Resource resource, ConfigProperties configProperties) {
     ResourceBuilder resourceBuilder = resource.toBuilder();
-    String resourceAttribute = resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE);
-    List<String> processArgs = resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS);
+    String resourceAttribute =
+        resource.getAttribute(ProcessIncubatingAttributes.PROCESS_COMMAND_LINE);
+    List<String> processArgs =
+        resource.getAttribute(ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS);
 
     if (resourceAttribute != null) {
       resourceBuilder.put(
-          ResourceAttributes.PROCESS_COMMAND_LINE,
+          ProcessIncubatingAttributes.PROCESS_COMMAND_LINE,
           resourceAttribute.replaceAll("(sw.apm.service.key=)\\S+", "$1****"));
     }
 
@@ -45,7 +48,7 @@ public class ResourceCustomizer implements BiFunction<Resource, ConfigProperties
           processArgs.stream()
               .map(arg -> arg.replaceAll("(sw.apm.service.key=)\\S+", "$1****"))
               .collect(Collectors.toList());
-      resourceBuilder.put(ResourceAttributes.PROCESS_COMMAND_ARGS, args);
+      resourceBuilder.put(ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS, args);
     }
 
     ResourceCustomizer.resource = resourceBuilder.build();
@@ -53,7 +56,7 @@ public class ResourceCustomizer implements BiFunction<Resource, ConfigProperties
         .debug(
             String.format(
                 "This log line is used for validation only: service.name: %s",
-                resource.getAttribute(ResourceAttributes.SERVICE_NAME)));
+                resource.getAttribute(ServiceAttributes.SERVICE_NAME)));
     return ResourceCustomizer.resource;
   }
 

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
@@ -40,7 +40,8 @@ import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
 import java.util.Arrays;
 import java.util.List;
 
@@ -168,9 +169,9 @@ public class SolarwindsSampler implements Sampler {
   }
 
   private String constructUrl(Attributes attributes) {
-    String scheme = attributes.get(SemanticAttributes.URL_SCHEME);
-    String host = attributes.get(SemanticAttributes.SERVER_ADDRESS);
-    String target = attributes.get(SemanticAttributes.URL_PATH);
+    String scheme = attributes.get(UrlAttributes.URL_SCHEME);
+    String host = attributes.get(ServerAttributes.SERVER_ADDRESS);
+    String target = attributes.get(UrlAttributes.URL_PATH);
 
     String url = String.format("%s://%s%s", scheme, host, target);
     logger.trace(String.format("Constructed url: %s", url));

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
@@ -29,7 +29,9 @@ import com.solarwinds.opentelemetry.core.CustomTransactionNameDict;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -140,7 +142,7 @@ public class TransactionNameManager {
 
   private static String prefixTransactionNameWithDomainName(
       String transactionName, SpanData spanData) {
-    String httpHostValue = spanData.getAttributes().get(SemanticAttributes.SERVER_ADDRESS);
+    String httpHostValue = spanData.getAttributes().get(ServerAttributes.SERVER_ADDRESS);
     if (httpHostValue != null && !httpHostValue.isEmpty()) {
       if (transactionName.startsWith("/")) {
         return httpHostValue + transactionName;
@@ -213,14 +215,14 @@ public class TransactionNameManager {
     }
 
     // use "http.route"
-    String httpRoute = spanAttributes.get(SemanticAttributes.HTTP_ROUTE);
+    String httpRoute = spanAttributes.get(HttpAttributes.HTTP_ROUTE);
     if (httpRoute != null) {
       logger.trace(String.format("Using http.route (%s) as the transaction name", httpRoute));
       return httpRoute;
     }
 
     // get transaction name from url
-    String path = spanAttributes.get(SemanticAttributes.URL_PATH);
+    String path = spanAttributes.get(UrlAttributes.URL_PATH);
     if (customTransactionNamePattern
         != null) { // try forming transaction name by the custom configured pattern
       String transactionName =

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/UrlSampleRateConfigParser.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/UrlSampleRateConfigParser.java
@@ -129,7 +129,7 @@ public class UrlSampleRateConfigParser implements ConfigParser<String, TraceConf
       Map<ResourceMatcher, TraceConfig> result = new LinkedHashMap<ResourceMatcher, TraceConfig>();
       for (int i = 0; i < array.length(); i++) {
         JSONObject urlRateEntry = array.getJSONObject(i);
-        String objectName = (String) urlRateEntry.keys().next();
+        String objectName = urlRateEntry.keys().next();
 
         if (objectName == null) {
           throw new InvalidConfigException("Invalid url sample rate note found, index [" + i + "]");

--- a/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGeneratorTest.java
+++ b/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGeneratorTest.java
@@ -33,7 +33,7 @@ import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -101,9 +101,9 @@ class InboundMeasurementMetricsGeneratorTest {
             .setStatus(StatusData.ok())
             .setAttributes(
                 Attributes.of(
-                    SemanticAttributes.HTTP_REQUEST_METHOD,
+                    HttpAttributes.HTTP_REQUEST_METHOD,
                     "get",
-                    SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
+                    HttpAttributes.HTTP_RESPONSE_STATUS_CODE,
                     200L))
             .build();
 
@@ -141,9 +141,9 @@ class InboundMeasurementMetricsGeneratorTest {
             .setStatus(StatusData.error())
             .setAttributes(
                 Attributes.of(
-                    SemanticAttributes.HTTP_REQUEST_METHOD,
+                    HttpAttributes.HTTP_REQUEST_METHOD,
                     "get",
-                    SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
+                    HttpAttributes.HTTP_RESPONSE_STATUS_CODE,
                     500L))
             .build();
 
@@ -181,9 +181,9 @@ class InboundMeasurementMetricsGeneratorTest {
             .setStatus(StatusData.error())
             .setAttributes(
                 Attributes.of(
-                    SemanticAttributes.HTTP_REQUEST_METHOD,
+                    HttpAttributes.HTTP_REQUEST_METHOD,
                     "get",
-                    SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
+                    HttpAttributes.HTTP_RESPONSE_STATUS_CODE,
                     500L))
             .build();
 
@@ -212,7 +212,7 @@ class InboundMeasurementMetricsGeneratorTest {
             .setEndEpochNanos(10000)
             .setHasEnded(true)
             .setStatus(StatusData.ok())
-            .setAttributes(Attributes.of(SemanticAttributes.HTTP_REQUEST_METHOD, "get"))
+            .setAttributes(Attributes.of(HttpAttributes.HTTP_REQUEST_METHOD, "get"))
             .build();
 
     when(readWriteSpanMock.toSpanData()).thenReturn(testSpanData);

--- a/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/ResourceCustomizerTest.java
+++ b/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/ResourceCustomizerTest.java
@@ -16,12 +16,13 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -39,9 +40,10 @@ class ResourceCustomizerTest {
       Resource.create(
           Attributes.builder()
               .put(
-                  ResourceAttributes.PROCESS_COMMAND_LINE, "-Dsw.apm.service.key=token:chubi-token")
+                  ProcessIncubatingAttributes.PROCESS_COMMAND_LINE,
+                  "-Dsw.apm.service.key=token:chubi-token")
               .put(
-                  ResourceAttributes.PROCESS_COMMAND_ARGS,
+                  ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS,
                   Collections.singletonList("-Dsw.apm.service.key=token:chubi-token"))
               .build());
 
@@ -56,7 +58,8 @@ class ResourceCustomizerTest {
     Resource actual =
         tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
     assertEquals(
-        "-Dsw.apm.service.key=****", actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE));
+        "-Dsw.apm.service.key=****",
+        actual.getAttribute(ProcessIncubatingAttributes.PROCESS_COMMAND_LINE));
   }
 
   @Test
@@ -65,13 +68,14 @@ class ResourceCustomizerTest {
         Resource.create(
             Attributes.builder()
                 .put(
-                    ResourceAttributes.PROCESS_COMMAND_LINE, "-Duser.country=US -Duser.language=en")
+                    ProcessIncubatingAttributes.PROCESS_COMMAND_LINE,
+                    "-Duser.country=US -Duser.language=en")
                 .build());
     Resource actual =
         tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
     assertEquals(
         "-Duser.country=US -Duser.language=en",
-        actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE));
+        actual.getAttribute(ProcessIncubatingAttributes.PROCESS_COMMAND_LINE));
   }
 
   @Test
@@ -80,7 +84,8 @@ class ResourceCustomizerTest {
         tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
     assertEquals(
         "-Dsw.apm.service.key=****",
-        Objects.requireNonNull(actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS))
+        Objects.requireNonNull(
+                actual.getAttribute(ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS))
             .get(0));
   }
 
@@ -90,13 +95,13 @@ class ResourceCustomizerTest {
         Resource.create(
             Attributes.builder()
                 .put(
-                    ResourceAttributes.PROCESS_COMMAND_ARGS,
+                    ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS,
                     Arrays.asList("-Duser.country=US", "-Duser.language=en"))
                 .build());
     Resource actual =
         tested.apply(resource, DefaultConfigProperties.create(Collections.emptyMap()));
     assertEquals(
         Arrays.asList("-Duser.country=US", "-Duser.language=en"),
-        actual.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS));
+        actual.getAttribute(ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS));
   }
 }

--- a/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SpanAttributeNamingSchemeTest.java
+++ b/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SpanAttributeNamingSchemeTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +48,7 @@ class SpanAttributeNamingSchemeTest {
 
   @Test
   void verifyThatNameIsReturnedWhenOneAttributeExists() {
-    String name = tested.createName(Attributes.of(SemanticAttributes.HTTP_REQUEST_METHOD, "POST"));
+    String name = tested.createName(Attributes.of(HttpAttributes.HTTP_REQUEST_METHOD, "POST"));
     assertEquals("POST", name);
   }
 
@@ -56,7 +56,7 @@ class SpanAttributeNamingSchemeTest {
   void verifyThatNameIsReturnedWhenMoreThanOneAttributesExist() {
     Attributes attributes =
         Attributes.builder()
-            .put(SemanticAttributes.HTTP_REQUEST_METHOD, "POST")
+            .put(HttpAttributes.HTTP_REQUEST_METHOD, "POST")
             .put(AttributeKey.stringKey("Handler"), "Controller.segfault")
             .build();
 

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/HostIdResourceProvider.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/HostIdResourceProvider.java
@@ -57,7 +57,11 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.K8sIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 
 @AutoService(ResourceProvider.class)
 public class HostIdResourceProvider implements ResourceProvider {
@@ -67,49 +71,50 @@ public class HostIdResourceProvider implements ResourceProvider {
     AttributesBuilder builder = Attributes.builder();
 
     HostId hostId = ServerHostInfoReader.INSTANCE.getHostId();
-    builder.put(ResourceAttributes.CONTAINER_ID, hostId.getDockerContainerId());
-    builder.put(ResourceAttributes.PROCESS_PID, (long) hostId.getPid());
+    builder.put(ContainerIncubatingAttributes.CONTAINER_ID, hostId.getDockerContainerId());
+    builder.put(ProcessIncubatingAttributes.PROCESS_PID, (long) hostId.getPid());
     builder.put(AttributeKey.stringArrayKey("mac.addresses"), hostId.getMacAddresses());
 
     builder.put(
         AttributeKey.stringKey("azure.app.service.instance.id"),
         hostId.getAzureAppServiceInstanceId());
-    builder.put(ResourceAttributes.HOST_ID, hostId.getHerokuDynoId());
+    builder.put(HostIncubatingAttributes.HOST_ID, hostId.getHerokuDynoId());
     builder.put(AttributeKey.stringKey("sw.uams.client.id"), hostId.getUamsClientId());
     builder.put(AttributeKey.stringKey("uuid"), hostId.getUuid());
 
     HostId.K8sMetadata k8sMetadata = hostId.getK8sMetadata();
     if (k8sMetadata != null) {
-      builder.put(ResourceAttributes.K8S_POD_UID, k8sMetadata.getPodUid());
-      builder.put(ResourceAttributes.K8S_NAMESPACE_NAME, k8sMetadata.getNamespace());
-      builder.put(ResourceAttributes.K8S_POD_NAME, k8sMetadata.getPodName());
+      builder.put(K8sIncubatingAttributes.K8S_POD_UID, k8sMetadata.getPodUid());
+      builder.put(K8sIncubatingAttributes.K8S_NAMESPACE_NAME, k8sMetadata.getNamespace());
+      builder.put(K8sIncubatingAttributes.K8S_POD_NAME, k8sMetadata.getPodName());
     }
 
     HostId.AwsMetadata awsMetadata = hostId.getAwsMetadata();
     if (awsMetadata != null) {
-      builder.put(ResourceAttributes.HOST_ID, awsMetadata.getHostId());
-      builder.put(ResourceAttributes.HOST_NAME, awsMetadata.getHostName());
-      builder.put(ResourceAttributes.CLOUD_PROVIDER, awsMetadata.getCloudProvider());
+      builder.put(HostIncubatingAttributes.HOST_ID, awsMetadata.getHostId());
+      builder.put(HostIncubatingAttributes.HOST_NAME, awsMetadata.getHostName());
+      builder.put(CloudIncubatingAttributes.CLOUD_PROVIDER, awsMetadata.getCloudProvider());
 
-      builder.put(ResourceAttributes.CLOUD_ACCOUNT_ID, awsMetadata.getCloudAccountId());
-      builder.put(ResourceAttributes.CLOUD_PLATFORM, awsMetadata.getCloudPlatform());
+      builder.put(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, awsMetadata.getCloudAccountId());
+      builder.put(CloudIncubatingAttributes.CLOUD_PLATFORM, awsMetadata.getCloudPlatform());
       builder.put(
-          ResourceAttributes.CLOUD_AVAILABILITY_ZONE, awsMetadata.getCloudAvailabilityZone());
+          CloudIncubatingAttributes.CLOUD_AVAILABILITY_ZONE,
+          awsMetadata.getCloudAvailabilityZone());
 
-      builder.put(ResourceAttributes.CLOUD_REGION, awsMetadata.getCloudRegion());
-      builder.put(ResourceAttributes.HOST_IMAGE_ID, awsMetadata.getHostImageId());
-      builder.put(ResourceAttributes.HOST_TYPE, awsMetadata.getHostType());
+      builder.put(CloudIncubatingAttributes.CLOUD_REGION, awsMetadata.getCloudRegion());
+      builder.put(HostIncubatingAttributes.HOST_IMAGE_ID, awsMetadata.getHostImageId());
+      builder.put(HostIncubatingAttributes.HOST_TYPE, awsMetadata.getHostType());
     }
 
     HostId.AzureVmMetadata azureVmMetadata = hostId.getAzureVmMetadata();
     if (azureVmMetadata != null) {
-      builder.put(ResourceAttributes.HOST_ID, azureVmMetadata.getHostId());
-      builder.put(ResourceAttributes.HOST_NAME, azureVmMetadata.getHostName());
-      builder.put(ResourceAttributes.CLOUD_PROVIDER, azureVmMetadata.getCloudProvider());
+      builder.put(HostIncubatingAttributes.HOST_ID, azureVmMetadata.getHostId());
+      builder.put(HostIncubatingAttributes.HOST_NAME, azureVmMetadata.getHostName());
+      builder.put(CloudIncubatingAttributes.CLOUD_PROVIDER, azureVmMetadata.getCloudProvider());
 
-      builder.put(ResourceAttributes.CLOUD_ACCOUNT_ID, azureVmMetadata.getCloudAccountId());
-      builder.put(ResourceAttributes.CLOUD_PLATFORM, azureVmMetadata.getCloudPlatform());
-      builder.put(ResourceAttributes.CLOUD_REGION, azureVmMetadata.getCloudRegion());
+      builder.put(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, azureVmMetadata.getCloudAccountId());
+      builder.put(CloudIncubatingAttributes.CLOUD_PLATFORM, azureVmMetadata.getCloudPlatform());
+      builder.put(CloudIncubatingAttributes.CLOUD_REGION, azureVmMetadata.getCloudRegion());
 
       builder.put(AttributeKey.stringKey("azure.vm.name"), azureVmMetadata.getAzureVmName());
       builder.put(AttributeKey.stringKey("azure.vm.size"), azureVmMetadata.getAzureVmSize());
@@ -122,9 +127,9 @@ public class HostIdResourceProvider implements ResourceProvider {
           azureVmMetadata.getAzureVmScaleSetName());
     }
 
-    builder.put(ResourceAttributes.HOST_NAME, hostId.getHostname());
-    builder.put(ResourceAttributes.CLOUD_AVAILABILITY_ZONE, hostId.getEc2AvailabilityZone());
-    builder.put(ResourceAttributes.HOST_ID, hostId.getEc2InstanceId());
+    builder.put(HostIncubatingAttributes.HOST_NAME, hostId.getHostname());
+    builder.put(CloudIncubatingAttributes.CLOUD_AVAILABILITY_ZONE, hostId.getEc2AvailabilityZone());
+    builder.put(HostIncubatingAttributes.HOST_ID, hostId.getEc2InstanceId());
     return Resource.create(builder.build());
   }
 }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java
@@ -18,13 +18,13 @@ package com.solarwinds.opentelemetry.extensions;
 
 import static com.solarwinds.opentelemetry.extensions.initialize.AutoConfigurationCustomizerProviderImpl.isAgentEnabled;
 import static com.solarwinds.opentelemetry.extensions.initialize.AutoConfigurationCustomizerProviderImpl.setAgentEnabled;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_COMMAND_ARGS;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_COMMAND_LINE;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_RUNTIME_DESCRIPTION;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_RUNTIME_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_RUNTIME_VERSION;
-import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_LANGUAGE;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_LANGUAGE;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_LINE;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_RUNTIME_DESCRIPTION;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_RUNTIME_NAME;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_RUNTIME_VERSION;
 
 import com.google.auto.service.AutoService;
 import com.solarwinds.joboe.config.ConfigGroup;

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsInboundMetricsSpanProcessor.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsInboundMetricsSpanProcessor.java
@@ -42,7 +42,7 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -159,15 +159,14 @@ public class SolarwindsInboundMetricsSpanProcessor implements SpanProcessor {
 
       final Map<String, String> aoSecondaryKey = new HashMap<>();
       boolean hasError = spanData.getStatus().getStatusCode() == StatusCode.ERROR;
-      final Long status =
-          spanData.getAttributes().get(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE);
+      final Long status = spanData.getAttributes().get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE);
 
       if (status != null) {
         aoSecondaryKey.put("HttpStatus", String.valueOf(status));
         swoTags.put("http.status_code", String.valueOf(status));
       }
 
-      final String method = spanData.getAttributes().get(SemanticAttributes.HTTP_REQUEST_METHOD);
+      final String method = spanData.getAttributes().get(HttpAttributes.HTTP_REQUEST_METHOD);
       if (method != null) {
         aoSecondaryKey.put("HttpMethod", method);
         swoTags.put("http.method", method);

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsPropertiesSupplier.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsPropertiesSupplier.java
@@ -35,6 +35,7 @@ public class SolarwindsPropertiesSupplier implements Supplier<Map<String, String
 
       PROPERTIES.put("otel.java.experimental.span-stacktrace.filter", SPAN_STACKTRACE_FILTER_CLASS);
       PROPERTIES.put("otel.propagators", String.format("tracecontext,baggage,%s", COMPONENT_NAME));
+      PROPERTIES.put("otel.semconv-stability.opt-in", "database/dup");
     } else {
       PROPERTIES.put("otel.sdk.disabled", "true");
     }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSpanExporter.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSpanExporter.java
@@ -37,7 +37,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.ExceptionAttributes;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -99,7 +99,7 @@ public class SolarwindsSpanExporter implements SpanExporter {
           entryEvent.report(eventReporter);
 
           for (EventData event : spanData.getEvents()) {
-            if (SemanticAttributes.EXCEPTION_EVENT_NAME.equals(event.getName())) {
+            if ("exception".equals(event.getName())) {
               reportErrorEvent(event);
             } else {
               reportInfoEvent(event);
@@ -134,14 +134,14 @@ public class SolarwindsSpanExporter implements SpanExporter {
 
   private static final List<AttributeKey<?>> OPEN_TELEMETRY_ERROR_ATTRIBUTE_KEYS =
       Arrays.asList(
-          SemanticAttributes.EXCEPTION_MESSAGE,
-          SemanticAttributes.EXCEPTION_TYPE,
-          SemanticAttributes.EXCEPTION_STACKTRACE);
+          ExceptionAttributes.EXCEPTION_MESSAGE,
+          ExceptionAttributes.EXCEPTION_TYPE,
+          ExceptionAttributes.EXCEPTION_STACKTRACE);
 
   private void reportErrorEvent(EventData eventData) {
     final Event event = Context.createEvent();
     final Attributes attributes = eventData.getAttributes();
-    String message = attributes.get(SemanticAttributes.EXCEPTION_MESSAGE);
+    String message = attributes.get(ExceptionAttributes.EXCEPTION_MESSAGE);
     if (message == null) {
       message = "";
     }
@@ -151,11 +151,11 @@ public class SolarwindsSpanExporter implements SpanExporter {
         "Spec",
         "error",
         "ErrorClass",
-        attributes.get(SemanticAttributes.EXCEPTION_TYPE),
+        attributes.get(ExceptionAttributes.EXCEPTION_TYPE),
         "ErrorMsg",
         message,
         "Backtrace",
-        attributes.get(SemanticAttributes.EXCEPTION_STACKTRACE));
+        attributes.get(ExceptionAttributes.EXCEPTION_STACKTRACE));
 
     final Map<AttributeKey<?>, Object> otherKvs = filterAttributes(attributes);
     OPEN_TELEMETRY_ERROR_ATTRIBUTE_KEYS.forEach(otherKvs.keySet()::remove);

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
@@ -72,6 +72,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 public class ConfigurationLoader {
@@ -571,11 +572,17 @@ public class ConfigurationLoader {
     }
 
     if (configs.containsProperty(ConfigProperty.AGENT_TRANSACTION_NAMING_SCHEMES)) {
-      List<TransactionNamingScheme> schemes =
-          (List<TransactionNamingScheme>)
-              configs.get(ConfigProperty.AGENT_TRANSACTION_NAMING_SCHEMES);
-      NamingScheme namingScheme = NamingScheme.createDecisionChain(schemes);
-      TransactionNameManager.setNamingScheme(namingScheme);
+      Object schemes = configs.get(ConfigProperty.AGENT_TRANSACTION_NAMING_SCHEMES);
+      if (schemes instanceof List<?>) {
+        List<TransactionNamingScheme> transactionNamingSchemes =
+            ((List<?>) schemes)
+                .stream()
+                    .filter(scheme -> scheme instanceof TransactionNamingScheme)
+                    .map(TransactionNamingScheme.class::cast)
+                    .collect(Collectors.toList());
+        NamingScheme namingScheme = NamingScheme.createDecisionChain(transactionNamingSchemes);
+        TransactionNameManager.setNamingScheme(namingScheme);
+      }
     }
 
     Boolean profilerEnabledFromEnvVar = null;

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/config/livereload/ConfigurationFileWatcher.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/config/livereload/ConfigurationFileWatcher.java
@@ -91,10 +91,9 @@ public final class ConfigurationFileWatcher {
           continue;
         }
 
-        WatchEvent<Path> ev = (WatchEvent<Path>) event;
-        Path filename = ev.context();
-        if (filename.endsWith(this.filename)) {
-          fileChangeListener.accept(filename);
+        Object filePath = event.context();
+        if (filePath instanceof Path && ((Path) filePath).endsWith(this.filename)) {
+          fileChangeListener.accept(((Path) filePath));
         }
       }
       boolean valid = key.reset();

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/HostIdResourceProviderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/HostIdResourceProviderTest.java
@@ -16,11 +16,12 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +37,8 @@ class HostIdResourceProviderTest {
     Resource resource =
         hostIdResourceProvider.createResource(
             DefaultConfigProperties.create(Collections.emptyMap()));
-    Long pid = resource.getAttribute(ResourceAttributes.PROCESS_PID);
-    String hostname = resource.getAttribute(ResourceAttributes.HOST_NAME);
+    Long pid = resource.getAttribute(ProcessIncubatingAttributes.PROCESS_PID);
+    String hostname = resource.getAttribute(HostIncubatingAttributes.HOST_NAME);
 
     assertNotNull(pid);
     assertNotNull(hostname);

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -11,7 +11,7 @@ val joboeVersion = "10.0.17"
 
 val opentelemetryJavaagentAlpha = "$otelAgentVersion-alpha"
 val opentelemetryAlpha = "$otelSdkVersion-alpha"
-val opentelemetrySemconv = "1.28.0-alpha"
+val opentelemetrySemconv = "1.29.0-alpha"
 
 val autoservice = "1.0.1"
 val otelJavaContribVersion = "1.41.0-alpha"
@@ -55,7 +55,6 @@ dependencies {
 
     api("net.bytebuddy:byte-buddy:${byteBuddyVersion}")
     api("com.google.auto.service:auto-service:$autoservice")
-    api("com.google.auto.service:auto-service-annotations:$autoservice")
 
     api("org.projectlombok:lombok:1.18.28")
     api("com.solarwinds.joboe:core:$joboeVersion")
@@ -69,6 +68,9 @@ dependencies {
     api("com.google.code.gson:gson:2.10.1")
     api("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
+    api("com.google.code.findbugs:annotations:3.0.1u2")
     api("io.opentelemetry.contrib:opentelemetry-span-stacktrace:$otelJavaContribVersion")
+    api("io.opentelemetry.semconv:opentelemetry-semconv-incubating:$opentelemetrySemconv")
+
   }
 }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v4_0/LoaderInstrumentationTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/java/com/solarwinds/opentelemetry/instrumentation/hibernate/v4_0/LoaderInstrumentationTest.java
@@ -22,6 +22,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.ServiceRegistryBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +52,12 @@ class LoaderInstrumentationTest {
         .setProperty("hibernate.hbm2ddl.auto", "create")
         .setProperty("hibernate.show_sql", "true");
 
-    sessionFactory = configuration.addAnnotatedClass(Dev.class).buildSessionFactory();
+    ServiceRegistry serviceRegistry =
+        new ServiceRegistryBuilder()
+            .applySettings(configuration.getProperties())
+            .buildServiceRegistry();
+    sessionFactory =
+        configuration.addAnnotatedClass(Dev.class).buildSessionFactory(serviceRegistry);
 
     Session session = sessionFactory.openSession();
     Transaction transaction = session.beginTransaction();

--- a/instrumentation/instrumentation-shared/src/test/java/com/solarwinds/opentelemetry/instrumentation/jdbc/shared/DbConstraintCheckerTest.java
+++ b/instrumentation/instrumentation-shared/src/test/java/com/solarwinds/opentelemetry/instrumentation/jdbc/shared/DbConstraintCheckerTest.java
@@ -16,7 +16,8 @@
 
 package com.solarwinds.opentelemetry.instrumentation.jdbc.shared;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.solarwinds.joboe.config.ConfigManager;
 import com.solarwinds.joboe.config.ConfigProperty;

--- a/instrumentation/jdbc/build.gradle.kts
+++ b/instrumentation/jdbc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   compileOnly("com.solarwinds.joboe:logging")
   compileOnly("io.opentelemetry:opentelemetry-sdk-trace")
 
-  compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
+  compileOnly("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
   compileOnly("com.github.ben-manes.caffeine:caffeine")
 
   testImplementation(project(":instrumentation:jdbc"))

--- a/instrumentation/jdbc/src/main/java/com/solarwinds/opentelemetry/instrumentation/StatementTruncator.java
+++ b/instrumentation/jdbc/src/main/java/com/solarwinds/opentelemetry/instrumentation/StatementTruncator.java
@@ -24,7 +24,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.lang.reflect.Method;
 
 public class StatementTruncator {
@@ -44,7 +44,7 @@ public class StatementTruncator {
          * */
         Method getAttribute = span.getClass().getDeclaredMethod("getAttribute", AttributeKey.class);
         getAttribute.setAccessible(true);
-        sql = (String) getAttribute.invoke(span, SemanticAttributes.DB_STATEMENT);
+        sql = (String) getAttribute.invoke(span, DbIncubatingAttributes.DB_QUERY_TEXT);
       } catch (Throwable throwable) {
         logger.debug("Cannot execute method getAttribute: " + throwable);
       }
@@ -59,7 +59,7 @@ public class StatementTruncator {
       if (sql.length() > sqlMaxLength) {
         sql = sql.substring(0, sqlMaxLength);
         span.setAttribute(QueryTruncatedAttributeKey.KEY, true);
-        span.setAttribute(SemanticAttributes.DB_STATEMENT, sql);
+        span.setAttribute(DbIncubatingAttributes.DB_QUERY_TEXT, sql);
         logger.debug(
             "SQL Query trimmed as its length ["
                 + sql.length()

--- a/long-running-test-arch/xk6/Dockerfile
+++ b/long-running-test-arch/xk6/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM --platform=amd64 golang:1.22.1 AS build
+FROM --platform=amd64 golang:1.23.0 AS build
 WORKDIR /app
 COPY go.mod go.mod
 COPY k6_otel.go k6_otel.go

--- a/long-running-test-arch/xk6/go.mod
+++ b/long-running-test-arch/xk6/go.mod
@@ -1,42 +1,44 @@
 module xk6-otel-output
 
-go 1.21.0
+go 1.23.0
 
 require (
-	go.k6.io/k6 v0.49.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.24.0
-	go.opentelemetry.io/otel/sdk v1.24.0
-	go.opentelemetry.io/otel/sdk/metric v1.24.0
+	go.k6.io/k6 v0.56.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.33.0
+	go.opentelemetry.io/otel/sdk v1.33.0
+	go.opentelemetry.io/otel/sdk/metric v1.33.0
 )
 
 require (
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
-	github.com/fatih/color v1.16.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mstoykov/atlas v0.0.0-20220811071828-388f114305dd // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/afero v1.1.2 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 // indirect
-	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect
-	google.golang.org/grpc v1.61.1 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
-	gopkg.in/guregu/null.v3 v3.3.0 // indirect
+	github.com/spf13/afero v1.12.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.33.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0 // indirect
+	go.opentelemetry.io/otel/metric v1.33.0 // indirect
+	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250106144421-5f5ef82da422 // indirect
+	google.golang.org/grpc v1.69.4 // indirect
+	google.golang.org/protobuf v1.36.2 // indirect
+	gopkg.in/guregu/null.v3 v3.5.0 // indirect
 )


### PR DESCRIPTION
address compiler warnings and upgrade go modules. Most the warnings were deprecation warnings relating to SemConv attributes. Among all of them, note that the `DB_STATEMENT` is now `DB_QUERY_TEXT`