### PR TITLE
NH-98975: don't check filename in event just reload config

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
@@ -133,11 +133,10 @@ public class ConfigurationLoader {
 
         ConfigurationFileWatcher.restartWatch(
             Paths.get(configurationFileDir),
-            runtimeConfigFilename,
             watchPeriod,
             watchService,
             watchScheduler,
-            filePath -> {
+            () -> {
               try {
                 logger.info("Configuration file change detected. Reloading configuration");
                 loadConfigurations();


### PR DESCRIPTION
This reloads config file whenever there's a change in the watched directory instead of checking that the filename match. This is because in some deployments, the filename is obfuscated.