### PR TITLE
NH-100526: update build config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,32 +429,31 @@ jobs:
             org.opencontainers.image.description=Solarwinds OTEL distro Java agent
             org.opencontainers.image.vendor=SolarWinds Worldwide, LLC
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
+      - name: Build and push -> linux/amd64
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: agent
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          load: true
 
-      - name: Analyze for critical and high CVEs
-        id: docker-scout-cves
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: "fs://./"
-          platform: "linux/amd64"
-          ignore-base: true
-          only-package-types: maven
-
-      - name: Analyze for critical and high CVEs
-        id: docker-scout-image-cves
+      - name: Analyze for critical and high CVEs -> linux/amd64
         uses: docker/scout-action@v1
         with:
           command: cves
           image: ${{ steps.meta.outputs.tags[0] }}
           platform: "linux/amd64"
+
+      - name: Build and push -> linux/arm64,linux/s390x,linux/ppc64le
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: agent
+          platforms: linux/arm64,linux/s390x,linux/ppc64le
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   ghrc_io:
     runs-on: ubuntu-latest

--- a/smoke-tests/solarwinds-apm-settings.json
+++ b/smoke-tests/solarwinds-apm-settings.json
@@ -1,12 +1,12 @@
 [
     {
         "arguments": {
-            "BucketCapacity": 1000000,
+            "BucketCapacity": 500000,
             "BucketRate": 1.0,
             "MetricsFlushInterval": 60,
-            "TriggerRelaxedBucketCapacity": 1000000,
+            "TriggerRelaxedBucketCapacity": 500000,
             "TriggerRelaxedBucketRate": 1.0,
-            "TriggerStrictBucketCapacity": 1000000,
+            "TriggerStrictBucketCapacity": 500000,
             "TriggerStrictBucketRate": 1.0
         },
         "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
@@ -14,6 +14,6 @@
         "timestamp": 1698176407,
         "ttl": 120,
         "type": 0,
-        "value": 1000000
+        "value": 500000
     }
 ]


### PR DESCRIPTION
For the scanning to work correctly `load` on the push action needs to be set to `true`. According to the docs, this causes the action to load the image in the local registry; however, it doesn't work for mult-platform build. Hence, scanned build shouldn't be multi-platform build. Sample [run.](https://github.com/solarwinds/apm-java/actions/runs/13337031290)