### PR TITLE
NH-100900: migrate to new creds

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,7 @@ permissions:
   packages: write
   contents: read
   id-token: write
+  security-events: write
 
 env:
   SW_APM_DEBUG_LEVEL: trace
@@ -588,3 +589,76 @@ jobs:
 
       - name: Publish
         run: ./gradlew publishToSonatype
+
+  docker_hub:
+    name: run scan on commit without pushing image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set agent version
+        id: set_version
+        uses: ./.github/actions/version
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_SOLARWINDS_ORG_LOGIN }}
+          password: ${{ secrets.ENOPS5919_APM_DOCKER_HUB_CI_OAT }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository_owner }}/autoinstrumentation-java
+          tags: |
+            type=raw,value=${{ steps.set_version.outputs.version }}
+            type=raw,value=latest
+          labels: |
+            maintainer=swo-librarians
+            org.opencontainers.image.title=apm-java
+            org.opencontainers.image.description=Solarwinds OTEL distro Java agent
+            org.opencontainers.image.vendor=SolarWinds Worldwide, LLC
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: agent
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
+          password: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
+
+      - name: Analyze for critical and high CVEs -> linux/amd64
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ${{ steps.meta.outputs.tags[0] }}
+          platform: "linux/amd64"
+          sarif-file: sarif.output.json
+
+      - name: Upload SARIF result
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif.output.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ permissions:
   packages: write
   contents: write
   id-token: write
+  security-events: write
 
 env:
   GITHUB_USERNAME: ${{ github.actor }}
@@ -412,8 +413,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_CI_USER }}
-          password: ${{ secrets.DOCKER_HUB_CI_PASSWORD }}
+          username: ${{ vars.DOCKER_SOLARWINDS_ORG_LOGIN }}
+          password: ${{ secrets.ENOPS5919_APM_DOCKER_HUB_CI_OAT }}
 
       - name: Extract Docker metadata
         id: meta
@@ -439,13 +440,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           load: true
 
-      - name: Analyze for critical and high CVEs -> linux/amd64
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: ${{ steps.meta.outputs.tags[0] }}
-          platform: "linux/amd64"
-
       - name: Build and push -> linux/arm64,linux/s390x,linux/ppc64le
         uses: docker/build-push-action@v6
         with:
@@ -454,6 +448,25 @@ jobs:
           platforms: linux/arm64,linux/s390x,linux/ppc64le
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
+          password: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
+
+      - name: Analyze for critical and high CVEs -> linux/amd64
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ${{ steps.meta.outputs.tags[0] }}
+          platform: "linux/amd64"
+          sarif-file: sarif.output.json
+
+      - name: Upload SARIF result
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif.output.json
 
   ghrc_io:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Tl;dr**: migrate to new creds

**Context**:

use new creds for image publishing and scanning.  also added image scanning for commits so that stuff can be caught early instead only at time of release.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
