### PR TITLE
NH-105119: update how url is being constructed

### DIFF
--- a/buildSrc/src/main/kotlin/solarwinds.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/solarwinds.java-conventions.gradle.kts
@@ -101,6 +101,8 @@ dependencies {
   testImplementation("com.solarwinds.joboe:core")
   testImplementation("com.solarwinds.joboe:metrics")
   testImplementation("org.junit-pioneer:junit-pioneer")
+
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
 }
 
 tasks {

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
@@ -168,12 +168,29 @@ public class SolarwindsSampler implements Sampler {
     return result;
   }
 
-  private String constructUrl(Attributes attributes) {
+  String constructUrl(Attributes attributes) {
     String scheme = attributes.get(UrlAttributes.URL_SCHEME);
     String host = attributes.get(ServerAttributes.SERVER_ADDRESS);
-    String target = attributes.get(UrlAttributes.URL_PATH);
+    String path = attributes.get(UrlAttributes.URL_PATH);
 
-    String url = String.format("%s://%s%s", scheme, host, target);
+    String url = attributes.get(UrlAttributes.URL_FULL);
+    if (url == null) {
+      StringBuilder builder = new StringBuilder();
+      if (scheme != null) {
+        builder.append(scheme).append("://");
+      }
+
+      if (host != null) {
+        builder.append(host);
+      }
+
+      if (path != null) {
+        builder.append(path);
+      }
+
+      url = builder.toString();
+    }
+
     logger.trace(String.format("Constructed url: %s", url));
     return url;
   }

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -15,6 +15,7 @@ val opentelemetrySemconv = "1.29.0-alpha"
 
 val autoservice = "1.0.1"
 val otelJavaContribVersion = "1.43.0-alpha"
+val junit5 = "5.9.2"
 
 rootProject.extra["otelAgentVersion"] = otelAgentVersion
 rootProject.extra["otelSdkVersion"] = otelSdkVersion
@@ -30,8 +31,8 @@ dependencies {
     api("org.mockito:mockito-inline:$mockitoVersion")
 
     api("javax.annotation:javax.annotation-api:1.3.2")
-    api("org.junit.jupiter:junit-jupiter-api:5.9.2")
-    api("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    api("org.junit.jupiter:junit-jupiter-api:$junit5")
+    api("org.junit.jupiter:junit-jupiter-engine:$junit5")
 
     api("io.opentelemetry:opentelemetry-api:$otelSdkVersion")
     api("io.opentelemetry.javaagent:opentelemetry-javaagent:$otelAgentVersion")
@@ -71,6 +72,7 @@ dependencies {
     api("com.google.code.findbugs:annotations:3.0.1u2")
     api("io.opentelemetry.contrib:opentelemetry-span-stacktrace:$otelJavaContribVersion")
     api("io.opentelemetry.semconv:opentelemetry-semconv-incubating:$opentelemetrySemconv")
+    api("org.junit.jupiter:junit-jupiter-params:$junit5")
 
   }
 }

--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -261,6 +261,9 @@ function verify_distributed_trace() {
             const {data: {traceArchive: {traceSpans: {edges}}}} = spanDataResponse
             console.log("Edges: ", edges)
 
+
+            let contextCheck = false
+            let sdkCheck = false
             for (let i = 0; i < edges.length; i++) {
                 const edge = edges[i]
                 const {node: {events}} = edge
@@ -271,8 +274,22 @@ function verify_distributed_trace() {
 
                     for (let k = 0; k < properties.length; k++) {
                         const property = properties[k]
-                        check(property, {"check that remote service, java-apm-smoke-test, is path of the trace": prop => prop.value === "java-apm-smoke-test"})
-                        check(property, {"sdk-trace": prop => prop.value === "SDK.trace.test"})
+                        check(property, {
+                            "check that remote service, java-apm-smoke-test, is path of the trace": prop => {
+                                contextCheck = prop.value === "java-apm-smoke-test"
+                                return contextCheck
+                            }
+                        })
+                        check(property, {
+                            "sdk-trace": prop => {
+                                sdkCheck = prop.value === "SDK.trace.test"
+                                return sdkCheck
+                            }
+                        })
+                    }
+
+                    if (contextCheck && sdkCheck) {
+                        return
                     }
                 }
             }


### PR DESCRIPTION
**Context**:

Update the code to `url.full` attribute if available otherwise try to reconstruct it. However, `url.full` is a client span attribute which means it won't able available for server spans. Added null checks because I was observing a couple of urls with null.
Also, updated one E2E test to terminate early once conditions are met. It looks like the backend is aggressive throttling the test services.

**Test Plan**:

Regression and updated unit test.

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
