### PR TITLE
NH-105119: remove logging of configured values

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/initialize/ConfigurationLoader.java
@@ -642,12 +642,8 @@ public class ConfigurationLoader {
   private static void setSystemProperty(String key, String value) {
     String propertyValue = getConfigValue(key);
     if (propertyValue == null) {
-      propertyValue = value;
       System.setProperty(key, value);
     }
-
-    logger.debug(
-        String.format("System configuration set with key-value -> %s = %s", key, propertyValue));
   }
 
   private static void setEndpoint(String key, String value) {


### PR DESCRIPTION
**Context**:

Removed because it leaks credentials when debug is enabled. Though it isn't exported, may still be exposed via log sharing.

**Test Plan**:

How it was tested or going to be tested

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
