### PR TITLE
NH-107404: ensure response is not committed before adding headers

### DIFF
--- a/instrumentation/servlet-3.0/build.gradle.kts
+++ b/instrumentation/servlet-3.0/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
   compileOnly("javax.servlet:javax.servlet-api:3.0.1")
   compileOnly(project(":custom"))
   compileOnly(project(":bootstrap"))
+
+  compileOnly("com.solarwinds.joboe:logging")
 }
 
 swoJava {

--- a/instrumentation/servlet-3.0/src/main/java/com/solarwinds/opentelemetry/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet-3.0/src/main/java/com/solarwinds/opentelemetry/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -16,6 +16,7 @@
 
 package com.solarwinds.opentelemetry.instrumentation.servlet.v3_0;
 
+import com.solarwinds.joboe.logging.LoggerFactory;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -35,8 +36,12 @@ public class Servlet3Advice {
       @Advice.Argument(value = 1, readOnly = false) ServletResponse response) {
     if (response instanceof HttpServletResponse) {
       HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-      if (!httpServletResponse.containsHeader(XTRACE_HEADER)) {
+      if (!response.isCommitted() && !httpServletResponse.containsHeader(XTRACE_HEADER)) {
         injectXtraceHeader(httpServletResponse);
+      } else if (response.isCommitted()) {
+        LoggerFactory.getLogger()
+            .info(
+                "[Servlet 3] Did not add x-trace header because ServletResponse has been committed");
       }
     }
   }

--- a/instrumentation/servlet-5.0/build.gradle.kts
+++ b/instrumentation/servlet-5.0/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")
   compileOnly(project(":custom"))
   compileOnly(project(":bootstrap"))
+
+  compileOnly("com.solarwinds.joboe:logging")
 }
 
 swoJava {

--- a/instrumentation/servlet-5.0/src/main/java/com/solarwinds/opentelemetry/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
+++ b/instrumentation/servlet-5.0/src/main/java/com/solarwinds/opentelemetry/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
@@ -16,6 +16,7 @@
 
 package com.solarwinds.opentelemetry.instrumentation.servlet.v5_0.service;
 
+import com.solarwinds.joboe.logging.LoggerFactory;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -36,8 +37,12 @@ public class JakartaServletServiceAdvice {
       @Advice.Argument(value = 1, readOnly = false) ServletResponse response) {
     if (response instanceof HttpServletResponse) {
       HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-      if (!httpServletResponse.containsHeader(XTRACE_HEADER)) {
+      if (!response.isCommitted() && !httpServletResponse.containsHeader(XTRACE_HEADER)) {
         injectXtraceHeader(httpServletResponse);
+      } else if (response.isCommitted()) {
+        LoggerFactory.getLogger()
+            .info(
+                "[Servlet 5] Did not add x-trace header because ServletResponse has been committed");
       }
     }
   }


### PR DESCRIPTION
This scenario can occur in a multithreaded application.

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
