### PR TITLE
NH-107707: upgrade to upstream `2.15.0`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins{
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
-val swoAgentVersion = "2.14.0"
+val swoAgentVersion = "2.15.0"
 extra["swoAgentVersion"] = swoAgentVersion
 group = "io.github.appoptics"
 version = if (System.getenv("SNAPSHOT_BUILD").toBoolean()) "$swoAgentVersion-SNAPSHOT" else swoAgentVersion

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
   `java-platform`
 }
 
-val otelAgentVersion = "2.14.0"
-val otelSdkVersion = "1.48.0"
+val otelAgentVersion = "2.15.0"
+val otelSdkVersion = "1.49.0"
 
 val mockitoVersion = "4.11.0"
 val byteBuddyVersion = "1.15.10"
@@ -14,7 +14,7 @@ val opentelemetryAlpha = "$otelSdkVersion-alpha"
 val opentelemetrySemconv = "1.29.0-alpha"
 
 val autoservice = "1.0.1"
-val otelJavaContribVersion = "1.43.0-alpha"
+val otelJavaContribVersion = "1.46.0-alpha"
 val junit5 = "5.9.2"
 
 rootProject.extra["otelAgentVersion"] = otelAgentVersion


### PR DESCRIPTION

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
