### PR TITLE
NH-112743: read config when needed and cache

### DIFF
--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
@@ -48,7 +48,7 @@ public class TransactionNameManager {
   public static final int MAX_TRANSACTION_NAME_LENGTH = 255;
   public static final String TRANSACTION_NAME_ELLIPSIS = "...";
 
-  private static final String[] customTransactionNamePattern;
+  private static String[] customTransactionNamePattern = null;
   static final Cache<String, String> URL_TRANSACTION_NAME_CACHE =
       Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(Duration.ofMinutes(20)).build();
 
@@ -59,7 +59,6 @@ public class TransactionNameManager {
   private static NamingScheme namingScheme = new DefaultNamingScheme(null);
 
   static {
-    customTransactionNamePattern = getTransactionNamePattern();
     addNameCountChangeListener();
   }
 
@@ -193,6 +192,11 @@ public class TransactionNameManager {
 
     // get transaction name from url
     String path = spanAttributes.get(UrlAttributes.URL_PATH);
+
+    if (customTransactionNamePattern == null) {
+      customTransactionNamePattern = getTransactionNamePattern();
+    }
+
     if (customTransactionNamePattern
         != null) { // try forming transaction name by the custom configured pattern
       String transactionName =


### PR DESCRIPTION
**Context**:

Cache on first read instead of static read because config may not be ready by the time the class is loaded.

**Test Plan**:

regression

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
