### PR TITLE
NH-101159: refactor

### DIFF
--- a/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/FileSettingsReader.java
+++ b/custom/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/FileSettingsReader.java
@@ -23,12 +23,13 @@ import com.solarwinds.joboe.logging.Logger;
 import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.SamplingException;
 import com.solarwinds.joboe.sampling.Settings;
+import com.solarwinds.opentelemetry.extensions.config.JsonSetting;
+import com.solarwinds.opentelemetry.extensions.config.JsonSettingWrapper;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class FileSettingsReader {
   private final String settingsFilePath;
@@ -36,7 +37,7 @@ public class FileSettingsReader {
   private static final Logger logger = LoggerFactory.getLogger();
 
   private static final Gson gson = new GsonBuilder().create();
-  private final Type type = new TypeToken<List<JsonSettings>>() {}.getType();
+  private final Type type = new TypeToken<List<JsonSetting>>() {}.getType();
 
   public FileSettingsReader(String settingsFilePath) {
     this.settingsFilePath = settingsFilePath;
@@ -46,7 +47,8 @@ public class FileSettingsReader {
     Settings settings = null;
     try {
       byte[] bytes = Files.readAllBytes(Paths.get(settingsFilePath));
-      List<Settings> kvSetting = convertToSettingsMap(gson.fromJson(new String(bytes), type));
+      List<Settings> kvSetting =
+          JsonSettingWrapper.fromJsonSettings(gson.fromJson(new String(bytes), type));
       logger.debug(String.format("Got settings from file: %s", kvSetting));
 
       if (!kvSetting.isEmpty()) {
@@ -58,9 +60,5 @@ public class FileSettingsReader {
       throw new SamplingException("Error reading settings from file");
     }
     return settings;
-  }
-
-  private List<Settings> convertToSettingsMap(List<JsonSettings> jsonSettings) {
-    return jsonSettings.stream().map(FileSettings::new).collect(Collectors.toList());
   }
 }

--- a/custom/lambda/src/test/java/com/solarwinds/opentelemetry/extensions/JsonSettingWrapperTest.java
+++ b/custom/lambda/src/test/java/com/solarwinds/opentelemetry/extensions/JsonSettingWrapperTest.java
@@ -21,19 +21,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.solarwinds.joboe.sampling.SamplingException;
 import com.solarwinds.joboe.sampling.SettingsArg;
+import com.solarwinds.opentelemetry.extensions.config.JsonSettingWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class FileSettingsTest {
-  private FileSettings tested;
+class JsonSettingWrapperTest {
+  private JsonSettingWrapper tested;
 
   private final FileSettingsReader reader =
       new FileSettingsReader(
-          FileSettingsTest.class.getResource("/solarwinds-apm-settings.json").getPath());
+          JsonSettingWrapperTest.class.getResource("/solarwinds-apm-settings.json").getPath());
 
   @BeforeEach
   void setup() throws SamplingException {
-    tested = (FileSettings) reader.getSettings();
+    tested = (JsonSettingWrapper) reader.getSettings();
   }
 
   @Test

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/JsonSetting.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/JsonSetting.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.solarwinds.opentelemetry.extensions;
+package com.solarwinds.opentelemetry.extensions.config;
 
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -24,7 +24,7 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor
-public class JsonSettings {
+public class JsonSetting {
   private Map<String, Object> arguments;
 
   private String flags;

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/JsonSettingWrapper.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/JsonSettingWrapper.java
@@ -14,38 +14,40 @@
  * limitations under the License.
  */
 
-package com.solarwinds.opentelemetry.extensions;
+package com.solarwinds.opentelemetry.extensions.config;
 
 import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.Settings;
 import com.solarwinds.joboe.sampling.SettingsArg;
+import java.util.List;
+import java.util.stream.Collectors;
 
-public class FileSettings extends Settings {
-  private final JsonSettings jsonSettings;
+public class JsonSettingWrapper extends Settings {
+  private final JsonSetting jsonSetting;
 
-  public FileSettings(JsonSettings jsonSettings) {
-    this.jsonSettings = jsonSettings;
+  public JsonSettingWrapper(JsonSetting jsonSetting) {
+    this.jsonSetting = jsonSetting;
   }
 
   @Override
   public long getValue() {
-    return jsonSettings.getValue();
+    return jsonSetting.getValue();
   }
 
   @Override
   public long getTimestamp() {
-    return jsonSettings.getTimestamp();
+    return jsonSetting.getTimestamp();
   }
 
   @Override
   public short getType() {
-    return jsonSettings.getType();
+    return jsonSetting.getType();
   }
 
   @Override
   public short getFlags() {
     short flags = 0;
-    String[] flagTokens = jsonSettings.getFlags().split(",");
+    String[] flagTokens = jsonSetting.getFlags().split(",");
     for (String flagToken : flagTokens) {
       if ("OVERRIDE".equals(flagToken)) {
         flags |= OBOE_SETTINGS_FLAG_OVERRIDE;
@@ -68,13 +70,17 @@ public class FileSettings extends Settings {
 
   @Override
   public long getTtl() {
-    return jsonSettings.getTtl();
+    return jsonSetting.getTtl();
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public <T> T getArgValue(SettingsArg<T> settingsArg) {
-    Object value = jsonSettings.getArguments().get(settingsArg.getKey());
+    Object value = jsonSetting.getArguments().get(settingsArg.getKey());
     return settingsArg.readValue(value);
+  }
+
+  public static List<Settings> fromJsonSettings(List<JsonSetting> jsonSettings) {
+    return jsonSettings.stream().map(JsonSettingWrapper::new).collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
**Context**:

refactor a little to enable code reuse for new `getSettings` implementation.

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
