### PR TITLE
NH-116076: bump auto-service

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -14,7 +14,7 @@ val opentelemetryAlpha = "$otelSdkVersion-alpha"
 val opentelemetrySemconv = "1.34.0"
 val opentelemetrySemconvAlpha = "1.34.0-alpha"
 
-val autoservice = "1.0.1"
+val autoservice = "1.1.1"
 val otelJavaContribVersion = "1.47.0-alpha"
 val junit5 = "5.9.2"
 

--- a/smoke-tests/netty-test-no-agent/build.gradle.kts
+++ b/smoke-tests/netty-test-no-agent/build.gradle.kts
@@ -27,13 +27,6 @@ version = "unspecified"
 repositories {
     mavenCentral()
     maven {
-        url = URI.create("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-        credentials {
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_TOKEN")
-        }
-    }
-    maven {
         url = URI.create("https://central.sonatype.com/repository/maven-snapshots/")
         credentials {
             password = System.getenv("CENTRAL_TOKEN")

--- a/smoke-tests/netty-test/build.gradle.kts
+++ b/smoke-tests/netty-test/build.gradle.kts
@@ -28,13 +28,6 @@ version = "unspecified"
 repositories {
     mavenCentral()
     maven {
-        url = URI.create("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-        credentials {
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_TOKEN")
-        }
-    }
-    maven {
         url = URI.create("https://central.sonatype.com/repository/maven-snapshots/")
         credentials {
             password = System.getenv("CENTRAL_TOKEN")

--- a/smoke-tests/spring-boot-webmvc/build.gradle
+++ b/smoke-tests/spring-boot-webmvc/build.gradle
@@ -30,13 +30,6 @@ version = "0.0.1-SNAPSHOT"
 repositories {
   mavenCentral()
     maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-        credentials {
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_TOKEN")
-        }
-    }
-    maven {
         url = "https://central.sonatype.com/repository/maven-snapshots/"
         credentials {
             password = System.getenv("CENTRAL_TOKEN")


### PR DESCRIPTION
**Context**:

bump auto-service and sonatype repo config.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
