### PR TITLE
NH-118043: set uuid into `service.instance.id`

### DIFF
--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
@@ -205,12 +205,7 @@ public class SharedConfigCustomizerProvider implements DeclarativeConfigurationC
             .getString(ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(), "");
 
     String endpoint = solarwinds.getString(ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(), "");
-    if (endpoint.startsWith("http")) {
-      endpoint = endpoint.replaceAll("https?://apm", "https://otel");
-
-    } else {
-      endpoint = String.format("https://%s", endpoint.replace("apm", "otel"));
-    }
+    endpoint = endpoint.replaceAll("https?://apm|^apm", "https://otel");
 
     serviceKeyAndEndpoint[0] = ServiceKeyUtils.getApiKey(serviceKeyAndEndpoint[0]);
     serviceKeyAndEndpoint[1] = endpoint;

--- a/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
+++ b/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
@@ -215,4 +215,86 @@ class SharedConfigCustomizerProviderTest {
     assertEquals("https://otel.collector.com", otlp.getEndpoint());
     assertEquals("authorization=Bearer token", otlp.getHeadersList());
   }
+
+  @Test
+  void UrlShouldNotChangeWhenNotApm() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withInstrumentationDevelopment(
+                new InstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new HashMap<String, String>() {
+                                  {
+                                    put(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service");
+                                    put(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "http://example.com");
+                                  }
+                                })));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    LoggerProviderModel loggerProvider = openTelemetryConfigurationModel.getLoggerProvider();
+    LogRecordProcessorModel logRecordProcessorModel = loggerProvider.getProcessors().get(0);
+    BatchLogRecordProcessorModel batch = logRecordProcessorModel.getBatch();
+
+    assertNotNull(batch);
+    LogRecordExporterModel exporter = batch.getExporter();
+    OtlpGrpcExporterModel otlp = exporter.getOtlpGrpc();
+
+    assertNotNull(otlp);
+    assertEquals("http://example.com", otlp.getEndpoint());
+    assertEquals("authorization=Bearer token", otlp.getHeadersList());
+  }
+
+  @Test
+  void UrlShouldNotChangeWhenNotApm2() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withInstrumentationDevelopment(
+                new InstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new HashMap<String, String>() {
+                                  {
+                                    put(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service");
+                                    put(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "http://localhost:4317");
+                                  }
+                                })));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    LoggerProviderModel loggerProvider = openTelemetryConfigurationModel.getLoggerProvider();
+    LogRecordProcessorModel logRecordProcessorModel = loggerProvider.getProcessors().get(0);
+    BatchLogRecordProcessorModel batch = logRecordProcessorModel.getBatch();
+
+    assertNotNull(batch);
+    LogRecordExporterModel exporter = batch.getExporter();
+    OtlpGrpcExporterModel otlp = exporter.getOtlpGrpc();
+
+    assertNotNull(otlp);
+    assertEquals("http://localhost:4317", otlp.getEndpoint());
+    assertEquals("authorization=Bearer token", otlp.getHeadersList());
+  }
 }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtil.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtil.java
@@ -10,6 +10,7 @@ import io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.K8sIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 
 public final class HostIdResourceUtil {
   private HostIdResourceUtil() {}
@@ -28,6 +29,7 @@ public final class HostIdResourceUtil {
     builder.put(HostIncubatingAttributes.HOST_ID, hostId.getHerokuDynoId());
     builder.put(AttributeKey.stringKey("sw.uams.client.id"), hostId.getUamsClientId());
     builder.put(AttributeKey.stringKey("uuid"), hostId.getUuid());
+    builder.put(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID, hostId.getUuid());
 
     HostId.K8sMetadata k8sMetadata = hostId.getK8sMetadata();
     if (k8sMetadata != null) {

--- a/solarwinds-otel-sdk/build.gradle.kts
+++ b/solarwinds-otel-sdk/build.gradle.kts
@@ -76,7 +76,7 @@ publishing {
     }
 
     // FIXME: remove because it's only needed once
-    if(!System.getenv("SNAPSHOT_BUILD").toBoolean()){
+    if (!System.getenv("SNAPSHOT_BUILD").toBoolean()) {
       register<MavenPublication>("relocation") {
         pom {
           groupId = "io.github.appoptics"


### PR DESCRIPTION
**Context**:

set uuid into `service.instance.id` so that it doesn't use upstream default

**Test Plan**:

regression and add additional unit tests for url

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
