### PR TITLE
NH-118708: add sample `sdk-config.yaml`

### DIFF
--- a/sdk-config.yaml
+++ b/sdk-config.yaml
@@ -1,0 +1,76 @@
+# sdk-config.yaml is a typical starting point for configuring our custom distribution, including exporting to
+# localhost via OTLP.
+
+# NOTE: With the exception of env var substitution syntax (i.e. ${MY_ENV}), SDKs ignore
+# environment variables when interpreting config files. This including ignoring all env
+# vars defined in https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
+
+# The file format version.
+file_format: "0.4"
+
+# Configure if the SDK is disabled or not. This setting is optional, the default value when not provided is for the SDK to be enabled
+disabled: false
+
+# Configure resource for all signals.
+resource:
+  # Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
+  # Entries must contain .name nand .value, and may optionally include .type, which defaults ot "string" if not set. The value must match the type. Values for .type include: string, bool, int, double, string_array, bool_array, int_array, double_array.
+  attributes:
+    - name: service.name
+      value: swi-test-app
+
+# Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
+attribute_limits:
+
+# Configure tracer provider.
+tracer_provider:
+
+# Configure meter provider.
+meter_provider:
+
+# Configure logger provider.
+logger_provider:
+
+instrumentation/development:
+  java:
+    common:
+      default-enabled: true
+    solarwinds:
+      profiler:
+        enabled: false
+        interval: 20
+        excludePackages:
+          - java
+          - javax
+          - com.sun
+          - sun
+          - sunw
+      agent.logging:
+        level: info
+      agent.serviceKey: ""
+      # All `monitor.xxx` is now DEPRECATED and will be removed in a future version
+      monitor.jmx.enable: true
+      monitor.jmx.scopes: |
+        {
+          "java.lang:type=MemoryPool,*": [
+            "Usage"
+          ],
+          "java.lang:type=Memory": [
+            "HeapMemoryUsage",
+            "NonHeapMemoryUsage"
+          ],
+          "java.lang:type=GarbageCollector,*": [
+            "CollectionTime"
+          ],
+          "java.lang:type=Threading": [
+            "ThreadCount"
+          ],
+          "java.lang:type=OperatingSystem": [
+            "ProcessCpuTime",
+            "AvailableProcessors",
+            "ProcessCpuLoad"
+          ],
+          "java.lang:type=Runtime,*": [
+            "Uptime"
+          ]
+        }

--- a/smoke-tests/sdk-config.yaml
+++ b/smoke-tests/sdk-config.yaml
@@ -18,6 +18,8 @@ resource:
   attributes:
     - name: service.name
       value: java-apm-smoke-test
+    - name: test.app
+      value: java-apm-smoke-test-v2
 
 # Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
 attribute_limits:
@@ -115,6 +117,15 @@ instrumentation/development:
     common:
       default-enabled: true
     solarwinds:
+      profiler:
+        enabled: true
+        interval: 20
+        excludePackages:
+          - java
+          - javax
+          - com.sun
+          - sun
+          - sunw
       agent.logging:
         level: trace
       agent.sqlTag: true
@@ -135,6 +146,10 @@ instrumentation/development:
             - http.method
       agent.serviceKey: ${SW_APM_SERVICE_KEY}
       agent.collector: apm.collector.na-01.st-ssp.solarwinds.com
+      agent.spanStacktraceFilters:
+        - http.request.method
+        - process.pid
+      # All `monitor.xxx` is now DEPRECATED and will be removed in a future version
       monitor.jmx.enable: true
       monitor.jmx.scopes: |
         {


### PR DESCRIPTION
*Context*

add sample `sdk-config.yaml` so that it can be linked from documentation site.

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
