### PR TITLE
NH-119398: switch to `http/protobuf` and add proxy config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins{
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
-val swoAgentVersion = "3.0.0"
+val swoAgentVersion = "3.0.1"
 extra["swoAgentVersion"] = swoAgentVersion
 group = "com.solarwinds"
 version = if (System.getenv("SNAPSHOT_BUILD").toBoolean()) "$swoAgentVersion-SNAPSHOT" else swoAgentVersion

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
   compileOnly("io.opentelemetry:opentelemetry-api-incubator")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
 
   testImplementation(project(":custom:shared"))
   testImplementation("org.json:json")
@@ -44,6 +45,7 @@ dependencies {
 
   testImplementation("io.opentelemetry:opentelemetry-api-incubator")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  testImplementation("io.opentelemetry:opentelemetry-exporter-otlp")
 }
 
 tasks.withType(Checkstyle::class).configureEach {

--- a/custom/shared/build.gradle.kts
+++ b/custom/shared/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
 
   testImplementation("org.json:json")
   testImplementation("com.solarwinds.joboe:sampling")
+  testImplementation("io.opentelemetry:opentelemetry-exporter-otlp")
+
   testImplementation("io.opentelemetry:opentelemetry-api-incubator")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
 }

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SharedNames.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SharedNames.java
@@ -29,4 +29,8 @@ public final class SharedNames {
   // This is visible to customer via span layer and can be used to configure transaction
   // filtering setting.
   public static final String LAYER_NAME_PLACEHOLDER = "%s:%s";
+
+  public static final String SW_OTEL_PROXY_HOST_KEY = "sw.otel.exporter.proxy.host";
+
+  public static final String SW_OTEL_PROXY_PORT_KEY = "sw.otel.exporter.proxy.port";
 }

--- a/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/ProxyHelper.java
+++ b/custom/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/ProxyHelper.java
@@ -1,0 +1,15 @@
+package com.solarwinds.opentelemetry.extensions.config;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_HOST_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_PORT_KEY;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+public final class ProxyHelper {
+  private ProxyHelper() {}
+
+  public static boolean isProxyConfigured(ConfigProperties properties) {
+    return properties.getString(SW_OTEL_PROXY_HOST_KEY) != null
+        && properties.getInt(SW_OTEL_PROXY_PORT_KEY) != null;
+  }
+}

--- a/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/ProxyHelperTest.java
+++ b/custom/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/ProxyHelperTest.java
@@ -1,0 +1,42 @@
+package com.solarwinds.opentelemetry.extensions.config;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_HOST_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_PORT_KEY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProxyHelperTest {
+
+  @Mock private ConfigProperties configProperties;
+
+  @Test
+  void shouldReturnTrueWhenProxyConfigured() {
+    when(configProperties.getString(eq(SW_OTEL_PROXY_HOST_KEY))).thenReturn("localhost");
+    when(configProperties.getInt(eq(SW_OTEL_PROXY_PORT_KEY))).thenReturn(8080);
+
+    assertTrue(ProxyHelper.isProxyConfigured(configProperties));
+  }
+
+  @Test
+  void shouldReturnFalseWhenProxyHostMissing() {
+    when(configProperties.getString(eq(SW_OTEL_PROXY_HOST_KEY))).thenReturn(null);
+    assertFalse(ProxyHelper.isProxyConfigured(configProperties));
+  }
+
+  @Test
+  void shouldReturnFalseWhenProxyPortMissing() {
+    when(configProperties.getString(eq(SW_OTEL_PROXY_HOST_KEY))).thenReturn("localhost");
+    when(configProperties.getInt(eq(SW_OTEL_PROXY_PORT_KEY))).thenReturn(null);
+
+    assertFalse(ProxyHelper.isProxyConfigured(configProperties));
+  }
+}

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/LogRecordExporterCustomizer.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/LogRecordExporterCustomizer.java
@@ -1,0 +1,37 @@
+package com.solarwinds.opentelemetry.extensions.config;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_HOST_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_PORT_KEY;
+
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.common.export.ProxyOptions;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+public class LogRecordExporterCustomizer
+    implements BiFunction<LogRecordExporter, ConfigProperties, LogRecordExporter> {
+
+  @Override
+  public LogRecordExporter apply(
+      LogRecordExporter logRecordExporter, ConfigProperties configProperties) {
+    if (ProxyHelper.isProxyConfigured(configProperties)
+        && logRecordExporter instanceof OtlpHttpLogRecordExporter) {
+      OtlpHttpLogRecordExporterBuilder builder =
+          ((OtlpHttpLogRecordExporter) (logRecordExporter)).toBuilder();
+
+      return builder
+          .setProxyOptions(
+              ProxyOptions.create(
+                  new InetSocketAddress(
+                      Objects.requireNonNull(configProperties.getString(SW_OTEL_PROXY_HOST_KEY)),
+                      Objects.requireNonNull(configProperties.getInt(SW_OTEL_PROXY_PORT_KEY)))))
+          .build();
+    }
+
+    return logRecordExporter;
+  }
+}

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/SpanExporterCustomizer.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/SpanExporterCustomizer.java
@@ -1,0 +1,34 @@
+package com.solarwinds.opentelemetry.extensions.config;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_HOST_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_PORT_KEY;
+
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.common.export.ProxyOptions;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+public class SpanExporterCustomizer
+    implements BiFunction<SpanExporter, ConfigProperties, SpanExporter> {
+
+  @Override
+  public SpanExporter apply(SpanExporter spanExporter, ConfigProperties configProperties) {
+    if (ProxyHelper.isProxyConfigured(configProperties)
+        && spanExporter instanceof OtlpHttpSpanExporter) {
+      OtlpHttpSpanExporterBuilder builder = ((OtlpHttpSpanExporter) (spanExporter)).toBuilder();
+      return builder
+          .setProxy(
+              ProxyOptions.create(
+                  new InetSocketAddress(
+                      Objects.requireNonNull(configProperties.getString(SW_OTEL_PROXY_HOST_KEY)),
+                      Objects.requireNonNull(configProperties.getInt(SW_OTEL_PROXY_PORT_KEY)))))
+          .build();
+    }
+
+    return spanExporter;
+  }
+}

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/AutoConfigurationCustomizerProviderImpl.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/AutoConfigurationCustomizerProviderImpl.java
@@ -27,6 +27,8 @@ import com.solarwinds.opentelemetry.extensions.ResourceCustomizer;
 import com.solarwinds.opentelemetry.extensions.SolarwindsPropertiesSupplier;
 import com.solarwinds.opentelemetry.extensions.SolarwindsTracerProviderCustomizer;
 import com.solarwinds.opentelemetry.extensions.config.ConfigurationLoader;
+import com.solarwinds.opentelemetry.extensions.config.LogRecordExporterCustomizer;
+import com.solarwinds.opentelemetry.extensions.config.SpanExporterCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
@@ -79,6 +81,8 @@ public class AutoConfigurationCustomizerProviderImpl
         .addPropertiesSupplier(new SolarwindsPropertiesSupplier())
         .addTracerProviderCustomizer(new SolarwindsTracerProviderCustomizer())
         .addMetricExporterCustomizer(new MetricExporterCustomizer())
+        .addSpanExporterCustomizer(new SpanExporterCustomizer())
+        .addLogRecordExporterCustomizer(new LogRecordExporterCustomizer())
         .addResourceCustomizer(new ResourceCustomizer());
   }
 

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/ConfigurationLoaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/ConfigurationLoaderTest.java
@@ -169,10 +169,10 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelLogExport(configContainer);
 
     assertEquals("otlp", System.getProperty("otel.logs.exporter"));
-    assertEquals("grpc", System.getProperty("otel.exporter.otlp.logs.protocol"));
+    assertEquals("http/protobuf", System.getProperty("otel.exporter.otlp.logs.protocol"));
 
     assertEquals(
-        "https://otel.collector.na-02.cloud.solarwinds.com",
+        "https://otel.collector.na-02.cloud.solarwinds.com/v1/logs",
         System.getProperty("otel.exporter.otlp.logs.endpoint"));
     assertEquals(
         "authorization=Bearer token", System.getProperty("otel.exporter.otlp.logs.headers"));
@@ -213,7 +213,7 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelLogExport(configContainer);
 
     assertEquals(
-        "https://otel.collector.na-02.staging.solarwinds.com",
+        "https://otel.collector.na-02.staging.solarwinds.com/v1/logs",
         System.getProperty("otel.exporter.otlp.logs.endpoint"));
   }
 
@@ -232,7 +232,7 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelLogExport(configContainer);
 
     assertEquals(
-        "https://otel.collector.na-01.cloud.solarwinds.com",
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/logs",
         System.getProperty("otel.exporter.otlp.logs.endpoint"));
   }
 
@@ -280,7 +280,7 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelLogExport(configContainer);
 
     assertEquals(
-        "https://otel.collector.na-01.cloud.solarwinds.com",
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/logs",
         System.getProperty("otel.exporter.otlp.logs.endpoint"));
   }
 
@@ -299,10 +299,10 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelMetricExport(configContainer);
 
     assertEquals("otlp", System.getProperty("otel.metrics.exporter"));
-    assertEquals("grpc", System.getProperty("otel.exporter.otlp.metrics.protocol"));
+    assertEquals("http/protobuf", System.getProperty("otel.exporter.otlp.metrics.protocol"));
 
     assertEquals(
-        "https://otel.collector.na-02.cloud.solarwinds.com",
+        "https://otel.collector.na-02.cloud.solarwinds.com/v1/metrics",
         System.getProperty("otel.exporter.otlp.metrics.endpoint"));
     assertEquals(
         "authorization=Bearer token", System.getProperty("otel.exporter.otlp.metrics.headers"));
@@ -343,7 +343,7 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelMetricExport(configContainer);
 
     assertEquals(
-        "https://otel.collector.na-02.staging.solarwinds.com",
+        "https://otel.collector.na-02.staging.solarwinds.com/v1/metrics",
         System.getProperty("otel.exporter.otlp.metrics.endpoint"));
   }
 
@@ -362,7 +362,7 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelMetricExport(configContainer);
 
     assertEquals(
-        "https://otel.collector.na-01.cloud.solarwinds.com",
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/metrics",
         System.getProperty("otel.exporter.otlp.metrics.endpoint"));
   }
 
@@ -395,8 +395,77 @@ class ConfigurationLoaderTest {
     ConfigurationLoader.configureOtelMetricExport(configContainer);
 
     assertEquals(
-        "https://otel.collector.na-01.cloud.solarwinds.com",
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/metrics",
         System.getProperty("otel.exporter.otlp.metrics.endpoint"));
+  }
+
+  @Test
+  @ClearSystemProperty(key = "otel.traces.exporter")
+  @ClearSystemProperty(key = "otel.exporter.otlp.traces.protocol")
+  @ClearSystemProperty(key = "otel.exporter.otlp.traces.headers")
+  @ClearSystemProperty(key = "otel.exporter.otlp.traces.endpoint")
+  void verifyDefaultEndpointIsUsedForTrace() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+
+    ConfigurationLoader.configureOtelTraceExport(configContainer);
+    assertEquals(
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/traces",
+        System.getProperty("otel.exporter.otlp.traces.endpoint"));
+  }
+
+  @Test
+  @SetSystemProperty(
+      key = "otel.exporter.otlp.endpoint",
+      value = "https://otel.collector.na-01.cloud.solarwinds.com")
+  @ClearSystemProperty(key = "otel.exporter.otlp.metrics.endpoint")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  @ClearSystemProperty(key = "otel.exporter.otlp.traces.endpoint")
+  void verifyMetricEndpointIsProperlyConfigured() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_METRICS_ENABLED, "true");
+    ConfigurationLoader.configureOtelMetricExport(configContainer);
+
+    assertEquals(
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/metrics",
+        System.getProperty("otel.exporter.otlp.metrics.endpoint"));
+  }
+
+  @Test
+  @SetSystemProperty(
+      key = "otel.exporter.otlp.endpoint",
+      value = "https://otel.collector.na-01.cloud.solarwinds.com")
+  @ClearSystemProperty(key = "otel.exporter.otlp.metrics.endpoint")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  @ClearSystemProperty(key = "otel.exporter.otlp.traces.endpoint")
+  void verifyLogsEndpointIsProperlyConfigured() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+
+    configContainer.putByStringValue(ConfigProperty.AGENT_EXPORT_LOGS_ENABLED, "true");
+    ConfigurationLoader.configureOtelLogExport(configContainer);
+    assertEquals(
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/logs",
+        System.getProperty("otel.exporter.otlp.logs.endpoint"));
+  }
+
+  @Test
+  @SetSystemProperty(
+      key = "otel.exporter.otlp.endpoint",
+      value = "https://otel.collector.na-01.cloud.solarwinds.com")
+  @ClearSystemProperty(key = "otel.exporter.otlp.metrics.endpoint")
+  @ClearSystemProperty(key = "otel.exporter.otlp.logs.endpoint")
+  @ClearSystemProperty(key = "otel.exporter.otlp.traces.endpoint")
+  void verifyTraceEndpointIsProperlyConfigured() throws InvalidConfigException {
+    ConfigContainer configContainer = new ConfigContainer();
+    configContainer.putByStringValue(ConfigProperty.AGENT_SERVICE_KEY, "token:service");
+
+    ConfigurationLoader.configureOtelTraceExport(configContainer);
+    assertEquals(
+        "https://otel.collector.na-01.cloud.solarwinds.com/v1/traces",
+        System.getProperty("otel.exporter.otlp.traces.endpoint"));
   }
 
   @Test

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/LogRecordExporterCustomizerTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/LogRecordExporterCustomizerTest.java
@@ -1,0 +1,41 @@
+package com.solarwinds.opentelemetry.extensions.config;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_HOST_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_PORT_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LogRecordExporterCustomizerTest {
+
+  private final LogRecordExporterCustomizer tested = new LogRecordExporterCustomizer();
+
+  @Mock private ConfigProperties configProperties;
+
+  @Mock private LogRecordExporter nonOtlpExporter;
+
+  @Test
+  void shouldReturnSameExporterWhenProxyNotConfigured() {
+    LogRecordExporter result = tested.apply(nonOtlpExporter, configProperties);
+    assertSame(nonOtlpExporter, result);
+  }
+
+  @Test
+  void shouldReturnNewExporterWhenProxyConfigured() {
+    when(configProperties.getString(SW_OTEL_PROXY_HOST_KEY)).thenReturn("localhost");
+    when(configProperties.getInt(SW_OTEL_PROXY_PORT_KEY)).thenReturn(8080);
+
+    OtlpHttpLogRecordExporter originalExporter = OtlpHttpLogRecordExporter.builder().build();
+    LogRecordExporter result = tested.apply(originalExporter, configProperties);
+    assertNotSame(originalExporter, result);
+  }
+}

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/SpanExporterCustomizerTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/SpanExporterCustomizerTest.java
@@ -1,0 +1,41 @@
+package com.solarwinds.opentelemetry.extensions.config;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_HOST_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.SW_OTEL_PROXY_PORT_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SpanExporterCustomizerTest {
+
+  private final SpanExporterCustomizer tested = new SpanExporterCustomizer();
+
+  @Mock private ConfigProperties configProperties;
+
+  @Mock private SpanExporter nonOtlpExporter;
+
+  @Test
+  void shouldReturnSameExporterWhenProxyNotConfigured() {
+    SpanExporter result = tested.apply(nonOtlpExporter, configProperties);
+    assertSame(nonOtlpExporter, result);
+  }
+
+  @Test
+  void shouldReturnNewExporterWhenProxyConfigured() {
+    when(configProperties.getString(SW_OTEL_PROXY_HOST_KEY)).thenReturn("localhost");
+    when(configProperties.getInt(SW_OTEL_PROXY_PORT_KEY)).thenReturn(8080);
+
+    OtlpHttpSpanExporter originalExporter = OtlpHttpSpanExporter.builder().build();
+    SpanExporter result = tested.apply(originalExporter, configProperties);
+    assertNotSame(originalExporter, result);
+  }
+}

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/provider/AutoConfigurationCustomizerProviderImplTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/provider/AutoConfigurationCustomizerProviderImplTest.java
@@ -62,6 +62,12 @@ class AutoConfigurationCustomizerProviderImplTest {
     when(autoConfigurationCustomizerMock.addMetricExporterCustomizer(any()))
         .thenReturn(autoConfigurationCustomizerMock);
 
+    when(autoConfigurationCustomizerMock.addLogRecordExporterCustomizer(any()))
+        .thenReturn(autoConfigurationCustomizerMock);
+
+    when(autoConfigurationCustomizerMock.addSpanExporterCustomizer(any()))
+        .thenReturn(autoConfigurationCustomizerMock);
+
     tested.customize(autoConfigurationCustomizerMock);
 
     verify(autoConfigurationCustomizerMock, atMostOnce()).addPropertiesCustomizer(any());
@@ -69,5 +75,8 @@ class AutoConfigurationCustomizerProviderImplTest {
 
     verify(autoConfigurationCustomizerMock, atMostOnce()).addResourceCustomizer(any());
     verify(autoConfigurationCustomizerMock, atMostOnce()).addMetricExporterCustomizer(any());
+
+    verify(autoConfigurationCustomizerMock, atMostOnce()).addSpanExporterCustomizer(any());
+    verify(autoConfigurationCustomizerMock, atMostOnce()).addLogRecordExporterCustomizer(any());
   }
 }

--- a/smoke-tests/src/test/java/com/solarwinds/containers/PetClinicRestContainer.java
+++ b/smoke-tests/src/test/java/com/solarwinds/containers/PetClinicRestContainer.java
@@ -160,6 +160,8 @@ public class PetClinicRestContainer implements Container {
     result.addAll(this.agent.getAdditionalJvmArgs());
     result.add("-javaagent:/app/" + agentJarPath.getFileName());
     result.add("-Dotel.metric.export.interval=100ms");
+    result.add("-Dsw.otel.exporter.proxy.host=squid-proxy");
+    result.add("-Dsw.otel.exporter.proxy.port=3128");
 
     result.add("-jar");
     result.add("/app/spring-petclinic-rest.jar");

--- a/smoke-tests/src/test/java/com/solarwinds/containers/SquidContainer.java
+++ b/smoke-tests/src/test/java/com/solarwinds/containers/SquidContainer.java
@@ -1,0 +1,49 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.containers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+public class SquidContainer implements Container {
+    private static final Logger logger = LoggerFactory.getLogger(SquidContainer.class);
+    private static final int PROXY_PORT = 3128;
+    private final Network network;
+
+    public SquidContainer(Network network) {
+        this.network = network;
+    }
+
+    @Override
+    public GenericContainer<?> build() {
+        return new GenericContainer<>(DockerImageName.parse("ubuntu/squid:5.2-22.04_beta"))
+                .withNetwork(network)
+                .withNetworkAliases("squid-proxy")
+                .withLogConsumer(new Slf4jLogConsumer(logger))
+                .withExposedPorts(PROXY_PORT)
+                .withFileSystemBind("./squid/passwd", "/etc/squid/passwd")
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(2)))
+                .withStartupTimeout(Duration.ofMinutes(2));
+    }
+}


### PR DESCRIPTION
**Context**:

Switch to `http/protobuf` OTLP protocol as default. Add exporter customizers to set proxy on exporters. Introduced two new configs for configuring the proxy settings. They will be manage by upstream code. This change cannot be configured via declarative config because auto-configuration doesn't work in declarative config.

**New configs**
- System props -> `sw.otel.exporter.proxy.host` or env -> `SW_OTEL_EXPORTER_PROXY_HOST`: for setting the host address
- System props -> `sw.otel.exporter.proxy.port` or  env -> `SW_OTEL_EXPORTER_PROXY_PORT`: for setting the listening port number

**Test Plan**:

Manually tested and added automated tests.

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
