### PR TITLE
New - expand trace flags and temp workaround for upstream bug.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -341,7 +341,7 @@ jobs:
     env:
       SMOKEV2: "true"
     needs:
-      - release-test
+      - s3-stage-upload
     steps:
       - uses: actions/checkout@v6
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -25,6 +25,8 @@ javaPlatform {
 }
 
 dependencies {
+  api(platform("io.netty:netty-bom:4.1.132.Final"))
+
   constraints {
     api("org.mockito:mockito-core:$mockitoVersion")
     api("org.mockito:mockito-junit-jupiter:$mockitoVersion")

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/TraceDecision.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/TraceDecision.java
@@ -17,6 +17,7 @@
 package com.solarwinds.joboe.sampling;
 
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Contains the result of trace decision (whether a request is sampled and whether metrics should be
@@ -28,6 +29,7 @@ import lombok.Getter;
  * @author pluk
  */
 @Getter
+@ToString
 public class TraceDecision {
   private final boolean sampled;
   private final boolean reportMetrics;

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/XtraceOptions.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/XtraceOptions.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Represents the data model from the `X-Trace-Options` request header.
@@ -39,6 +40,7 @@ import lombok.Getter;
  *
  * <p>Provides a method to look up {@link XtraceOption} with the corresponding typed value.
  */
+@ToString
 public class XtraceOptions {
   private static final Logger logger = LoggerFactory.getLogger();
   static final long TIMESTAMP_MAX_DELTA = 5 * 60; // 5 minutes in seconds

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/PropagatedContext.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/PropagatedContext.java
@@ -1,0 +1,41 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.opentelemetry.extensions;
+
+import com.solarwinds.joboe.sampling.XtraceOptions;
+
+/**
+ * Thread-local workaround for OTel SDK replacing the parent context with a primordial context for
+ * root spans (see open-telemetry/opentelemetry-java#8012). Remove once the upstream fix is shipped.
+ */
+final class PropagatedContext {
+  private static final ThreadLocal<XtraceOptions> XTRACE_OPTIONS = new ThreadLocal<>();
+
+  private PropagatedContext() {}
+
+  static void set(XtraceOptions options) {
+    XTRACE_OPTIONS.set(options);
+  }
+
+  static XtraceOptions getXtraceOptions() {
+    return XTRACE_OPTIONS.get();
+  }
+
+  static void clear() {
+    XTRACE_OPTIONS.remove();
+  }
+}

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/ResponseHeaderCustomizer.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/ResponseHeaderCustomizer.java
@@ -38,9 +38,13 @@ public class ResponseHeaderCustomizer implements HttpServerResponseCustomizer {
       RESPONSE response,
       HttpServerResponseMutator<RESPONSE> httpServerResponseMutator) {
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
-    String flags = spanContext.isSampled() ? "01" : "00";
     String traceContext =
-        "00-" + spanContext.getTraceId() + "-" + spanContext.getSpanId() + "-" + flags;
+        "00-"
+            + spanContext.getTraceId()
+            + "-"
+            + spanContext.getSpanId()
+            + "-"
+            + spanContext.getTraceFlags().asHex();
 
     httpServerResponseMutator.appendHeader(response, XTRACE_HEADER, traceContext);
     String xtraceOptionsResp = spanContext.getTraceState().get(SW_XTRACE_OPTIONS_RESP_KEY);

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SamplingUtil.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SamplingUtil.java
@@ -29,6 +29,7 @@ public class SamplingUtil {
   public static final String SW_TRACESTATE_KEY = "sw";
   public static final String SW_XTRACE_OPTIONS_RESP_KEY = "xtrace_options_response";
   static final Pattern SPAN_ID_REGEX = Pattern.compile("[0-9a-fA-F]{16}");
+  static final Pattern FLAGS_REGEX = Pattern.compile("[0-9a-fA-F]{2}");
 
   public static boolean isValidSwTraceState(String swVal) {
     if (swVal == null || !swVal.contains("-")) {
@@ -42,7 +43,7 @@ public class SamplingUtil {
 
     // 16 is the hex length of the Otel span id
     return (SPAN_ID_REGEX.matcher(swTraceState[0]).matches())
-        && (swTraceState[1].equals("00") || swTraceState[1].equals("01"));
+        && FLAGS_REGEX.matcher(swTraceState[1]).matches();
   }
 
   public static void addXtraceOptionsToAttribute(

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SamplingUtil.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SamplingUtil.java
@@ -28,22 +28,10 @@ public class SamplingUtil {
 
   public static final String SW_TRACESTATE_KEY = "sw";
   public static final String SW_XTRACE_OPTIONS_RESP_KEY = "xtrace_options_response";
-  static final Pattern SPAN_ID_REGEX = Pattern.compile("[0-9a-fA-F]{16}");
-  static final Pattern FLAGS_REGEX = Pattern.compile("[0-9a-fA-F]{2}");
+  static final Pattern SW_TRACESTATE_REGEX = Pattern.compile("[0-9a-fA-F]{16}-[0-9a-fA-F]{2}");
 
   public static boolean isValidSwTraceState(String swVal) {
-    if (swVal == null || !swVal.contains("-")) {
-      return false;
-    }
-
-    final String[] swTraceState = swVal.split("-");
-    if (swTraceState.length != 2) {
-      return false;
-    }
-
-    // 16 is the hex length of the Otel span id
-    return (SPAN_ID_REGEX.matcher(swTraceState[0]).matches())
-        && FLAGS_REGEX.matcher(swTraceState[1]).matches();
+    return swVal != null && SW_TRACESTATE_REGEX.matcher(swVal).matches();
   }
 
   public static void addXtraceOptionsToAttribute(

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsContextPropagator.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsContextPropagator.java
@@ -73,7 +73,7 @@ public class SolarwindsContextPropagator implements TextMapPropagator {
     // https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field
     final TraceState traceState = spanContext.getTraceState();
     final String swTraceStateValue =
-        spanContext.getSpanId() + "-" + (spanContext.isSampled() ? "01" : "00");
+        spanContext.getSpanId() + "-" + spanContext.getTraceFlags().asHex();
     setter.set(carrier, TRACE_STATE, updateTraceState(traceState, swTraceStateValue));
 
     final String traceOptions = context.get(TriggerTraceContextKey.XTRACE_OPTIONS);
@@ -171,6 +171,7 @@ public class SolarwindsContextPropagator implements TextMapPropagator {
         context =
             context.with(TriggerTraceContextKey.XTRACE_OPTIONS_SIGNATURE, traceOptionsSignature);
       }
+      PropagatedContext.set(xTraceOptions);
     }
 
     final String traceState = getter.get(carrier, TRACE_STATE);

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
@@ -104,68 +104,77 @@ public class SolarwindsSampler implements Sampler {
 
     final SamplingResult samplingResult;
     final AttributesBuilder additionalAttributesBuilder = Attributes.builder();
-    final XtraceOptions xTraceOptions = parentContext.get(TriggerTraceContextKey.KEY);
+    XtraceOptions xTraceOptions = parentContext.get(TriggerTraceContextKey.KEY);
+
+    if (xTraceOptions == null) {
+      xTraceOptions = PropagatedContext.getXtraceOptions();
+    }
 
     String xtraceOptionsResponseStr = null;
     List<String> signals =
         Arrays.asList(
             constructUrl(attributes), String.format(LAYER_NAME_PLACEHOLDER, spanKind, name.trim()));
 
-    if (!parentSpanContext.isValid()) { // no valid traceparent, it is a new trace
-      TraceDecision traceDecision = shouldTraceRequest(name, null, xTraceOptions, signals);
-      samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, true);
-      XTraceOptionsResponse xtraceOptionsResponse =
-          XTraceOptionsResponse.computeResponse(xTraceOptions, traceDecision, true);
-
-      if (xtraceOptionsResponse != null) {
-        xtraceOptionsResponseStr = xtraceOptionsResponse.toString();
-      }
-
-    } else if (parentSpanContext.isRemote()) {
-      final String swTraceState = traceState.get(SW_TRACESTATE_KEY);
-
-      if (SamplingUtil.isValidSwTraceState(swTraceState)) { // pass through for request counting
-        additionalAttributesBuilder.put(Constants.SW_PARENT_ID, swTraceState.split("-")[0]);
-        final String xTraceId = Util.w3cContextToHexString(parentSpanContext);
-        final TraceDecision traceDecision =
-            shouldTraceRequest(name, xTraceId, xTraceOptions, signals);
-
-        samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, false);
-        final XTraceOptionsResponse xTraceOptionsResponse =
-            XTraceOptionsResponse.computeResponse(xTraceOptions, traceDecision, false);
-
-        if (xTraceOptionsResponse != null) {
-          xtraceOptionsResponseStr = xTraceOptionsResponse.toString();
-        }
-
-      } else { // no swTraceState, treat it as a new trace
-        final TraceDecision traceDecision = shouldTraceRequest(name, null, xTraceOptions, signals);
+    try {
+      if (!parentSpanContext.isValid()) { // no valid traceparent, it is a new trace
+        TraceDecision traceDecision = shouldTraceRequest(name, null, xTraceOptions, signals);
         samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, true);
-
-        final XTraceOptionsResponse xTraceOptionsResponse =
+        XTraceOptionsResponse xtraceOptionsResponse =
             XTraceOptionsResponse.computeResponse(xTraceOptions, traceDecision, true);
-        if (xTraceOptionsResponse != null) {
-          xtraceOptionsResponseStr = xTraceOptionsResponse.toString();
+
+        if (xtraceOptionsResponse != null) {
+          xtraceOptionsResponseStr = xtraceOptionsResponse.toString();
         }
+
+      } else if (parentSpanContext.isRemote()) {
+        final String swTraceState = traceState.get(SW_TRACESTATE_KEY);
+
+        if (SamplingUtil.isValidSwTraceState(swTraceState)) { // pass through for request counting
+          additionalAttributesBuilder.put(Constants.SW_PARENT_ID, swTraceState.split("-")[0]);
+          final String xTraceId = Util.w3cContextToHexString(parentSpanContext);
+          final TraceDecision traceDecision =
+              shouldTraceRequest(name, xTraceId, xTraceOptions, signals);
+
+          samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, false);
+          final XTraceOptionsResponse xTraceOptionsResponse =
+              XTraceOptionsResponse.computeResponse(xTraceOptions, traceDecision, false);
+
+          if (xTraceOptionsResponse != null) {
+            xtraceOptionsResponseStr = xTraceOptionsResponse.toString();
+          }
+
+        } else { // no swTraceState, treat it as a new trace
+          final TraceDecision traceDecision =
+              shouldTraceRequest(name, null, xTraceOptions, signals);
+          samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, true);
+
+          final XTraceOptionsResponse xTraceOptionsResponse =
+              XTraceOptionsResponse.computeResponse(xTraceOptions, traceDecision, true);
+          if (xTraceOptionsResponse != null) {
+            xtraceOptionsResponseStr = xTraceOptionsResponse.toString();
+          }
+        }
+
+        final String traceStateValue = parentContext.get(TraceStateKey.KEY);
+        if (traceStateValue != null) {
+          additionalAttributesBuilder.put(Constants.SW_UPSTREAM_TRACESTATE, traceStateValue);
+        }
+
+      } else { // local span, continue with parent based sampling
+        samplingResult =
+            Sampler.parentBased(Sampler.alwaysOff())
+                .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
       }
 
-      final String traceStateValue = parentContext.get(TraceStateKey.KEY);
-      if (traceStateValue != null) {
-        additionalAttributesBuilder.put(Constants.SW_UPSTREAM_TRACESTATE, traceStateValue);
-      }
+      SamplingResult result =
+          TraceStateSamplingResult.wrap(
+              samplingResult, additionalAttributesBuilder.build(), xtraceOptionsResponseStr);
 
-    } else { // local span, continue with parent based sampling
-      samplingResult =
-          Sampler.parentBased(Sampler.alwaysOff())
-              .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+      logger.trace(String.format("Sampling decision: %s", result.getDecision()));
+      return result;
+    } finally {
+      PropagatedContext.clear();
     }
-
-    SamplingResult result =
-        TraceStateSamplingResult.wrap(
-            samplingResult, additionalAttributesBuilder.build(), xtraceOptionsResponseStr);
-
-    logger.trace(String.format("Sampling decision: %s", result.getDecision()));
-    return result;
   }
 
   String constructUrl(Attributes attributes) {

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SamplingUtilTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SamplingUtilTest.java
@@ -28,8 +28,14 @@ import com.solarwinds.joboe.sampling.TraceDecisionUtil;
 import com.solarwinds.joboe.sampling.XtraceOptions;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -83,51 +89,27 @@ class SamplingUtilTest {
     assertEquals("lo:se,check-id:123", builder.build().get(stringKey("SWKeys")));
   }
 
-  @Test
-  void returnTrueGivenValidSwTraceState() {
-    String swTraceState = "4025843a0f1f35f3-01";
+  static Stream<String> validHexFlags() {
+    return IntStream.rangeClosed(0x00, 0xff)
+        .mapToObj(i -> "4025843a0f1f35f3-" + String.format("%02x", i));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validHexFlags")
+  void returnTrueGivenValidSwTraceStateForAllHexFlags(String swTraceState) {
     assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
   }
 
-  @Test
-  void returnTrueGivenSwTraceStateWithFlag02() {
-    String swTraceState = "4025843a0f1f35f3-02";
-    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
-  }
-
-  @Test
-  void returnTrueGivenSwTraceStateWithFlag03() {
-    String swTraceState = "4025843a0f1f35f3-03";
-    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
-  }
-
-  @Test
-  void returnTrueGivenSwTraceStateWithAnyValidHexFlag() {
-    String swTraceState = "4025843a0f1f35f3-ff";
-    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
-  }
-
-  @Test
-  void returnFalseGivenSwTraceStateWithInvalidFlag() {
-    String swTraceState = "4025843a0f1f35f3-0g";
-    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
-  }
-
-  @Test
-  void returnFalseGivenSwTraceStateWithSpanIdLengthLessThan16() {
-    String swTraceState = "4025843a0f1f35f-01";
-    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
-  }
-
-  @Test
-  void returnFalseGivenSwTraceStateWithSpanIdLengthGreaterThan16() {
-    String swTraceState = "4025843a0f1f35f33-01";
-    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
-  }
-
-  @Test
-  void returnFalseGivenSwTraceStateWithInvalidFormat() {
-    String swTraceState = "4025843a0f1f3-5f-01";
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(
+      strings = {
+        "4025843a0f1f35f3-0g",
+        "4025843a0f1f35f-01",
+        "4025843a0f1f35f33-01",
+        "4025843a0f1f3-5f-01"
+      })
+  void returnFalseGivenInvalidSwTraceState(String swTraceState) {
     assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
   }
 }

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SamplingUtilTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SamplingUtilTest.java
@@ -90,8 +90,26 @@ class SamplingUtilTest {
   }
 
   @Test
+  void returnTrueGivenSwTraceStateWithFlag02() {
+    String swTraceState = "4025843a0f1f35f3-02";
+    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnTrueGivenSwTraceStateWithFlag03() {
+    String swTraceState = "4025843a0f1f35f3-03";
+    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnTrueGivenSwTraceStateWithAnyValidHexFlag() {
+    String swTraceState = "4025843a0f1f35f3-ff";
+    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
   void returnFalseGivenSwTraceStateWithInvalidFlag() {
-    String swTraceState = "4025843a0f1f35f3-11";
+    String swTraceState = "4025843a0f1f35f3-0g";
     assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
   }
 

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsContextPropagatorTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsContextPropagatorTest.java
@@ -204,6 +204,22 @@ class SolarwindsContextPropagatorTest {
   }
 
   @Test
+  void verifyThatExtractPopulatesPropagatedContext() {
+    PropagatedContext.clear();
+    final Map<String, String> carrier =
+        new HashMap<String, String>() {
+          {
+            put("X-Trace-Options", "trigger-trace;custom-senderhost=chubi;");
+          }
+        };
+
+    solarwindsContextPropagator.extract(Context.current(), carrier, textMapGetterStub);
+
+    assertNotNull(PropagatedContext.getXtraceOptions());
+    PropagatedContext.clear();
+  }
+
+  @Test
   void verifyThatTracestateIsExtractedAndPutIntoContext() {
     final Map<String, String> carrier =
         new HashMap<String, String>() {

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsSamplerTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsSamplerTest.java
@@ -269,6 +269,44 @@ class SolarwindsSamplerTest {
     }
   }
 
+  @Test
+  void verifyThatSamplerFallsBackToPropagatedContextForRootSpan() {
+    try (MockedStatic<Span> spanMockedStatic = mockStatic(Span.class);
+        MockedStatic<TraceDecisionUtil> traceDecisionUtilMockedStatic =
+            mockStatic(TraceDecisionUtil.class)) {
+      spanMockedStatic.when(() -> Span.fromContext(any())).thenReturn(spanMock);
+
+      when(spanContextMock.isValid()).thenReturn(false);
+      when(spanMock.getSpanContext()).thenReturn(spanContextMock);
+
+      when(traceDecisionMock.isSampled()).thenReturn(false);
+      when(traceDecisionMock.isReportMetrics()).thenReturn(false);
+
+      XtraceOptions realOptions =
+          XtraceOptions.getXTraceOptions("trigger-trace;custom-senderhost=test;", null);
+
+      ArgumentCaptor<XtraceOptions> xtraceCaptor = ArgumentCaptor.forClass(XtraceOptions.class);
+      traceDecisionUtilMockedStatic
+          .when(() -> TraceDecisionUtil.shouldTraceRequest(any(), any(), any(), any()))
+          .thenReturn(traceDecisionMock);
+
+      PropagatedContext.set(realOptions);
+
+      tested.shouldSample(
+          Context.root(),
+          idGenerator.generateTraceId(),
+          "name",
+          SpanKind.SERVER,
+          Attributes.empty(),
+          Collections.emptyList());
+
+      traceDecisionUtilMockedStatic.verify(
+          () -> TraceDecisionUtil.shouldTraceRequest(any(), any(), xtraceCaptor.capture(), any()));
+      assertEquals(realOptions, xtraceCaptor.getValue());
+      assertNull(PropagatedContext.getXtraceOptions());
+    }
+  }
+
   @ParameterizedTest
   @MethodSource("constructParams")
   void testConstructUrl(String expected, Attributes attributes) {

--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -38,7 +38,7 @@ function verify_that_trace_is_persisted() {
         const traceContext = petTypesResponse.headers['X-Trace']
         const [_, traceId, spanId, flag] = traceContext.split("-")
         console.log("Trace context -> ", traceContext)
-        if (flag === '00') continue;
+        if ((parseInt(flag, 16) & 1) === 0) continue;
 
         const traceDetailPayload = {
             "operationName": "getTraceDetails",
@@ -95,7 +95,7 @@ function verify_that_span_data_is_persisted() {
         const traceContext = newOwnerResponse.headers['X-Trace']
         const [_, traceId, __, flag] = traceContext.split("-")
         console.log("Trace context -> ", traceContext)
-        if (flag === '00') continue;
+        if ((parseInt(flag, 16) & 1) === 0) continue;
 
         const spanRawDataPayload = {
             "operationName": "getSubSpanRawData",
@@ -169,7 +169,7 @@ function verify_that_span_data_is_persisted_0() {
         const traceContext = response.headers['X-Trace']
         const [_, traceId, __, flag] = traceContext.split("-")
         console.log("Trace context -> ", traceContext)
-        if (flag === '00') continue;
+        if ((parseInt(flag, 16) & 1) === 0) continue;
 
         const spanRawDataPayload = {
             "operationName": "getSubSpanRawData",
@@ -232,7 +232,7 @@ function verify_distributed_trace() {
         const traceContext = response.headers['X-Trace']
         const [_, traceId, __, flag] = traceContext.split("-")
         console.log("[Distributed]Trace context -> ", traceContext)
-        if (flag === '00') continue;
+        if ((parseInt(flag, 16) & 1) === 0) continue;
 
         const spanRawDataPayload = {
             "operationName": "getSubSpanRawData",
@@ -303,7 +303,7 @@ function verify_that_specialty_path_is_not_sampled() {
     const traceContext = specialtiesResponse.headers['X-Trace']
 
     const [_, __, ___, flag] = traceContext.split("-")
-    check(flag, {"verify that transaction is filtered": f => f === "00"})
+    check(flag, {"verify that transaction is filtered": f => (parseInt(f, 16) & 1) === 0})
 }
 
 function verify_that_metrics_are_reported(metric, checkFn, service="lambda-e2e") {
@@ -430,7 +430,7 @@ function check_property(fn) {
         const traceContext = response.headers['X-Trace']
         const [_, traceId, __, flag] = traceContext.split("-")
         console.log("Trace context -> ", traceContext)
-        if (flag === '00') continue;
+        if ((parseInt(flag, 16) & 1) === 0) continue;
 
         const spanRawDataPayload = {
             "operationName": "getSubSpanRawData",

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -60,7 +60,7 @@ public class SmokeTest {
             List.of("hostId:.*i-[0-9a-z]+",
                     "hostId:.*[0-9a-z-]+",
                     "Extension attached!",
-                    "trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=(01|00)",
+                    "trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=[0-9a-f]{2}",
                     "This log line is used for validation only: service.name: java-apm-smoke-test",
                     "Applying instrumentation: sw-jdbc",
                     "Clearing transaction name buffer. Unique transaction count: \\d+",
@@ -188,7 +188,7 @@ public class SmokeTest {
 
     @Test
     void assertTraceContextInLog() {
-        Boolean actual = logStreamAnalyzer.getAnswer().get("trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=(01|00)");
+        Boolean actual = logStreamAnalyzer.getAnswer().get("trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=[0-9a-f]{2}");
         assertTrue(actual, "trace context is not injected in logs");
     }
 

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTestV2.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTestV2.java
@@ -59,7 +59,7 @@ public class SmokeTestV2 {
             List.of("hostId:.*i-[0-9a-z]+",
                     "hostId:.*[0-9a-z-]+",
                     "Extension attached!",
-                    "trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=(01|00)",
+                    "trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=[0-9a-f]{2}",
                     "This log line is used for validation only: service.name: java-apm-smoke-test",
                     "Applying instrumentation: sw-jdbc",
                     "Clearing transaction name buffer. Unique transaction count: \\d+")
@@ -180,7 +180,7 @@ public class SmokeTestV2 {
 
     @Test
     void assertTraceContextInLog() {
-        Boolean actual = logStreamAnalyzer.getAnswer().get("trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=(01|00)");
+        Boolean actual = logStreamAnalyzer.getAnswer().get("trace_id=[a-z0-9]+\\s+span_id=[a-z0-9]+\\s+trace_flags=[0-9a-f]{2}");
         assertTrue(actual, "trace context is not injected in logs");
     }
 


### PR DESCRIPTION
## Summary

Fixes an OTel SDK bug that silently drops `X-Trace-Options` for root spans, updates trace flag handling to support the full W3C hex byte spec instead of only `00`/`01`, pins Netty to 4.1.132.Final to address a CVE-2026-33871, and parallelizes the release smoke test in CI.

## Changes

### ThreadLocal fallback for `XtraceOptions` propagation

The OTel SDK has a bug ([opentelemetry-java#8012](https://github.com/open-telemetry/opentelemetry-java/issues/8012)) where it replaces the parent `Context` with `Context.root()` when constructing root spans. This discards any `XtraceOptions` placed in the context during `extract()`, causing trigger-trace and custom KVs from the `X-Trace-Options` header to be silently lost.

A new `PropagatedContext` class stores `XtraceOptions` in a `ThreadLocal` as a side-channel. This is safe because the OTel agent's `PropagatingFromUpstreamInstrumenter.start()` calls `extract()` and `shouldSample()` synchronously in the same method — no async gap, no thread switch — across all server instrumentations (Servlet, Netty, WebFlux, gRPC). The sampler reads from the `ThreadLocal` only when the context-based lookup returns null, and unconditionally clears it in a `finally` block.

### Trace flags handling

Previously, trace flags were hardcoded to `"00"` or `"01"` (sampled/not-sampled). The W3C trace context spec defines trace flags as a full hex byte, and upstream OTel now emits values beyond `01` (e.g., `02`, `03`). Changes:

- Replaces `isSampled() ? "01" : "00"` with `getTraceFlags().asHex()` in the context propagator and response header customizer
- Relaxes `sw` tracestate flag validation from exact `"00"`/`"01"` to a two-character hex pattern
- k6 smoke tests now use bitwise check (`parseInt(flag, 16) & 1`) instead of exact string comparison to determine sampled status, matching the W3C spec where bit 0 indicates the sampled flag
- Java smoke test assertions updated to accept any valid two-character hex flag

### Netty BOM for CVE remediation

Adds the Netty BOM (`io.netty:netty-bom:4.1.132.Final`) to centralized dependency management, pinning all transitive Netty dependencies to a version that addresses CVE-2026-33871.

### CI: parallelize release smoke test

The release smoke test job now depends on `s3-stage-upload` instead of `release-test`, removing the serial dependency and allowing it to run in parallel.

### Misc

- Adds `@ToString` (Lombok) to `TraceDecision` and `XtraceOptions` for better debug logging


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
