### PR TITLE
Internal - address code scanning and removed dead code

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessor.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessor.java
@@ -45,8 +45,7 @@ public class SolarwindsProfilingSpanProcessor implements ExtendedSpanProcessor {
       if (!parentSpanContext.isValid()
           || parentSpanContext.isRemote()) { // then a root span of this service
         if (isProfilingEnabled()) {
-          SpanContext spanContext = span.getSpanContext();
-          Metadata metadata = Util.buildMetadata(spanContext);
+          Metadata metadata = Util.buildMetadata(span.getSpanContext());
           if (metadata.isValid()) {
             Profiler.addProfiledThread(
                 Thread.currentThread(), metadata, Metadata.bytesToHex(metadata.getTaskID()));

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/Context.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/Context.java
@@ -16,75 +16,11 @@
 
 package com.solarwinds.joboe.core;
 
-import com.solarwinds.joboe.logging.Logger;
-import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.Metadata;
-import com.solarwinds.joboe.sampling.SamplingException;
-import com.solarwinds.joboe.sampling.SettingsArg;
-import com.solarwinds.joboe.sampling.SettingsArgChangeListener;
-import com.solarwinds.joboe.sampling.SettingsManager;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
-import java.util.Arrays;
 
 public class Context {
-  private static final ThreadLocal<Boolean> skipInheritingContextThreadLocal =
-      new ThreadLocal<Boolean>();
-  private static final Logger logger = LoggerFactory.getLogger();
-  private static boolean inheritContext =
-      true; // whether child thread should inherits metadata (clone) from parent
-
-  // Thread local storage for metadata. This is inheritable so that child threads pick up the
-  // parent's context.
-  private static final InheritableThreadLocal<Metadata> mdThreadLocal =
-      new InheritableThreadLocal<Metadata>() {
-        @Override
-        protected Metadata initialValue() {
-          Metadata md = new Metadata();
-          return md;
-        }
-
-        @Override
-        protected Metadata childValue(Metadata parentMetadata) {
-          if (!inheritContext
-              || (skipInheritingContextThreadLocal.get() != null
-                  && skipInheritingContextThreadLocal.get())) {
-            return new Metadata(); // do not propagate context here, return an empty context
-          } else {
-            Metadata clonedMetadata = new Metadata(parentMetadata);
-            // if parent span is sampled, that means a parent span exists then this is a child span
-            // spawn off from a thread from parent span, mark this as asynchronous
-            if (parentMetadata.isSampled()) {
-              clonedMetadata.setIsAsync(true);
-            }
-            return clonedMetadata;
-          }
-        }
-      };
-
-  static {
-    SettingsManager.registerListener(
-        new SettingsArgChangeListener<Boolean>(
-            SettingsArg
-                .DISABLE_INHERIT_CONTEXT) { // listen to Settings change on inheriting context
-          @Override
-          public void onChange(Boolean newValue) {
-            if (newValue != null) {
-              inheritContext = !newValue;
-            } else {
-              inheritContext = true; // by default we inherit context
-            }
-          }
-        });
-  }
-
-  public static Event createEvent() {
-    return createEventWithContext(getMetadata(), true);
-  }
-
-  public static Event createEventWithID(String metadataID) throws SamplingException {
-    return createEventWithIDAndContext(metadataID, getMetadata());
-  }
 
   public static Event createEventWithContext(Metadata context) {
     return createEventWithContext(context, true); // by default add edge (not trace start)
@@ -95,28 +31,6 @@ public class Context {
       return new EventImpl(context, addEdge);
     } else {
       return new NoopEvent(context);
-    }
-  }
-
-  public static Event createEventWithIDAndContext(String metadataID, Metadata currentContext)
-      throws SamplingException {
-    if (shouldCreateEvent(currentContext)) {
-      return new EventImpl(currentContext, metadataID, true);
-    } else {
-      return new NoopEvent(currentContext);
-    }
-  }
-
-  public static Event createEventWithGeneratedMetadata(Metadata generatedMetadata) {
-    return createEventWithGeneratedMetadata(null, generatedMetadata);
-  }
-
-  public static Event createEventWithGeneratedMetadata(
-      Metadata parentMetadata, Metadata generatedMetadata) {
-    if (shouldCreateEvent(generatedMetadata)) {
-      return new EventImpl(parentMetadata, generatedMetadata);
-    } else {
-      return new NoopEvent(generatedMetadata);
     }
   }
 
@@ -143,84 +57,11 @@ public class Context {
 
   /** Returns metadata for current thread */
   public static Metadata getMetadata() {
-    Metadata md = mdThreadLocal.get();
-    if (Arrays.equals(md.getTaskID(), Metadata.unsetTaskID)) {
-      SpanContext sc = Span.current().getSpanContext();
-      if (sc.isValid()) {
-        return new Metadata(sc);
-      }
-    }
-    return md;
-  }
-
-  /**
-   * Sets metadata for current thread.
-   *
-   * <p><b>Note:</b> This sets the metadata in the local thread storage only. It does NOT update the
-   * OpenTelemetry context. To propagate context via OpenTelemetry, please use {@code
-   * io.opentelemetry.context.Context.makeCurrent()}.
-   *
-   * @param md
-   * @deprecated Use OpenTelemetry Context propagation instead.
-   */
-  @Deprecated
-  public static void setMetadata(Metadata md) {
-    setMap(md);
-  }
-
-  /**
-   * Sets metadata for this thread from hex string
-   *
-   * <p><b>Note:</b> This sets the metadata in the local thread storage only. It does NOT update the
-   * OpenTelemetry context. To propagate context via OpenTelemetry, please use {@code
-   * io.opentelemetry.context.Context.makeCurrent()}.
-   *
-   * @param hexStr
-   * @throws SamplingException
-   * @deprecated Use OpenTelemetry Context propagation instead.
-   */
-  @Deprecated
-  public static void setMetadata(String hexStr) throws SamplingException {
-    Metadata md = new Metadata();
-    md.fromHexString(hexStr);
-    setMap(md);
-  }
-
-  /**
-   * Clears metadata for current thread.
-   *
-   * <p><b>Note:</b> This only clears the local thread storage. It does not affect any active
-   * OpenTelemetry Scope.
-   *
-   * @deprecated Use OpenTelemetry Context propagation instead.
-   */
-  @Deprecated
-  public static void clearMetadata() {
-    setMap(new Metadata());
-  }
-
-  private static void setMap(Metadata md) {
-    mdThreadLocal.set(md);
+    SpanContext sc = Span.current().getSpanContext();
+    return new Metadata(sc);
   }
 
   public static boolean isValid() {
     return getMetadata().isValid();
-  }
-
-  /**
-   * Set whether the any child threads spawned by the current thread should skip inheriting a clone
-   * of current context
-   *
-   * <p>It is known that in thread pool handling, using inheritable thread local has problem of
-   * leaking context. (unable to clear the context in the spawned thread afterwards) This can be set
-   * to true if the context propagation is handled by other means in order to avoid the leaking
-   * problem.
-   *
-   * <p>By default this is false
-   *
-   * @param skipInheritingContext
-   */
-  public static void setSkipInheritingContext(boolean skipInheritingContext) {
-    skipInheritingContextThreadLocal.set(skipInheritingContext);
   }
 }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/Event.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/Event.java
@@ -64,13 +64,6 @@ public abstract class Event {
   /**
    * Report event to agent
    *
-   * @param reporter
-   */
-  public abstract void report(EventReporter reporter);
-
-  /**
-   * Report event to agent
-   *
    * @param md metadata from context - if null, then no context metadata check and update will be
    *     done
    * @param reporter Event Reporter

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/EventImpl.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/EventImpl.java
@@ -242,14 +242,6 @@ public class EventImpl extends Event {
   }
 
   /* (non-Javadoc)
-   * @see com.solarwinds.joboe.core.Event#report(com.solarwinds.joboe.core.EventReporter)
-   */
-  @Override
-  public void report(EventReporter reporter) {
-    report(Context.getMetadata(), reporter);
-  }
-
-  /* (non-Javadoc)
    * @see com.solarwinds.joboe.core.Event#report(com.solarwinds.joboe.sampling.Metadata, com.solarwinds.joboe.core.EventReporter)
    */
   @Override

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/NoopEvent.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/NoopEvent.java
@@ -44,9 +44,6 @@ public class NoopEvent extends Event {
   public void setAsync() {}
 
   @Override
-  public void report(EventReporter reporter) {}
-
-  @Override
   public void report(Metadata md, EventReporter reporter) {}
 
   @Override

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcSettings.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcSettings.java
@@ -90,7 +90,7 @@ public class RpcSettings extends com.solarwinds.joboe.sampling.Settings {
       if (arg == null) {
         logger.debug("Cannot recognize argument [" + inputArg.getKey() + "], ignoring...");
       } else {
-        args.put(arg, arg.readValue(inputArg.getValue()));
+        args.put(arg, arg.readFromByteBuffer(inputArg.getValue()));
       }
     }
   }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/ServerHostInfoReader.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/ServerHostInfoReader.java
@@ -18,11 +18,9 @@ package com.solarwinds.joboe.core.util;
 
 import com.solarwinds.joboe.config.ConfigManager;
 import com.solarwinds.joboe.config.ConfigProperty;
-import com.solarwinds.joboe.core.Context;
 import com.solarwinds.joboe.core.HostId;
 import com.solarwinds.joboe.logging.Logger;
 import com.solarwinds.joboe.logging.LoggerFactory;
-import com.solarwinds.joboe.sampling.Metadata;
 import io.opentelemetry.api.internal.InstrumentationUtil;
 import java.io.BufferedReader;
 import java.io.File;
@@ -90,8 +88,6 @@ public class ServerHostInfoReader
   private static boolean checkedDistro = false;
   static HostInfoUtils.OsType osType = HostInfoUtils.getOsType();
 
-  static final String HOSTNAME_SEPARATOR = ";";
-
   enum DistroType {
     AMAZON,
     UBUNTU,
@@ -102,7 +98,7 @@ public class ServerHostInfoReader
     GENTOO
   }
 
-  static final Map<DistroType, String> DISTRO_FILE_NAMES = new HashMap<DistroType, String>();
+  static final Map<DistroType, String> DISTRO_FILE_NAMES = new HashMap<>();
 
   public static final String HOSTNAME_ALIAS_KEY = "ConfiguredHostname";
 
@@ -128,10 +124,6 @@ public class ServerHostInfoReader
 
   public String getAwsAvailabilityZone() {
     return Ec2InstanceReader.getAvailabilityZone();
-  }
-
-  public String getDockerContainerId() {
-    return DockerInfoReader.getDockerId();
   }
 
   public String getHerokuDynoId() {
@@ -162,7 +154,7 @@ public class ServerHostInfoReader
     private static final Map<String, NicStatus> ENUM_MAP;
 
     static {
-      Map<String, NicStatus> map = new ConcurrentHashMap<String, NicStatus>();
+      Map<String, NicStatus> map = new ConcurrentHashMap<>();
       for (NicStatus instance : NicStatus.values()) {
         map.put(instance.getDesc(), instance);
       }
@@ -178,24 +170,20 @@ public class ServerHostInfoReader
     }
   }
 
-  /**
-   * Get the network adapters status by executing a command on Windows.
-   *
-   * @param nicStatusMap
-   */
+  /** Get the network adapters status by executing a command on Windows. */
   private static void buildNicStatusMap(Map<String, NicStatus> nicStatusMap) {
     String output;
     try {
       output =
           ExecUtils.exec(
               "powershell.exe Get-NetAdapter -IncludeHidden | Select-Object InterfaceDescription,Status | Format-Table -AutoSize",
-              System.getProperty("line.separator"));
+              System.lineSeparator());
     } catch (Exception e) {
       logger.info("Failed to obtain nic status from exec `Get-NetAdapter` : " + e.getMessage());
       return;
     }
 
-    String[] lines = output.split(System.getProperty("line.separator"));
+    String[] lines = output.split(System.lineSeparator());
     if (lines.length < 3) {
       logger.info(
           "No enough data received from exec `Get-NetAdapter`("
@@ -230,17 +218,15 @@ public class ServerHostInfoReader
   /**
    * Extracts network interface info from the system. Take note that loop back, point-to-point and
    * non-physical addresses are excluded
-   *
-   * @return
    */
   @Override
   public HostInfoUtils.NetworkAddressInfo getNetworkAddressInfo() {
     try {
-      List<String> ips = new ArrayList<String>();
-      List<String> macAddresses = new ArrayList<String>();
+      List<String> ips = new ArrayList<>();
+      List<String> macAddresses = new ArrayList<>();
 
       // map of device id -> status
-      Map<String, NicStatus> nicStatusMap = new HashMap<String, NicStatus>();
+      Map<String, NicStatus> nicStatusMap = new HashMap<>();
       boolean isWindowsIPv4 = false;
       if (osType.equals(HostInfoUtils.OsType.WINDOWS)
           && Boolean.getBoolean("java.net.preferIPv4Stack")) {
@@ -352,7 +338,6 @@ public class ServerHostInfoReader
    *
    * <p>Take note that this definition is different from NetworkInterface.isVirtual()
    *
-   * @param networkInterface
    * @return
    */
   private static boolean isPhysicalInterface(NetworkInterface networkInterface) {
@@ -386,7 +371,6 @@ public class ServerHostInfoReader
    *
    * <p><a href="https://swicloud.atlassian.net/browse/AO-14670">...</a> for details
    *
-   * @param networkInterface
    * @return false if it's NOT a Microsoft Hyper-V Network Adapter or it's UP
    */
   private static boolean isGhostHyperV(NetworkInterface networkInterface) {
@@ -421,19 +405,10 @@ public class ServerHostInfoReader
   @Override
   public HostId getHostId() {
     if (hostId == null) {
-      Metadata existingMetdataContext = null;
-      try {
-        existingMetdataContext = Context.getMetadata();
-        Context.clearMetadata(); // make sure our init route does not accidentally trigger tracing
-        // instrumentations
-
-        // synchronously get it once first to ensure it's available at the return statement
-        hostId = buildHostId();
-        // also start the background checker here
-        startHostIdChecker();
-      } finally {
-        Context.setMetadata(existingMetdataContext); // set the existing context back
-      }
+      // synchronously get it once first to ensure it's available at the return statement
+      hostId = buildHostId();
+      // also start the background checker here
+      startHostIdChecker();
     }
     return hostId;
   }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/TimeUtils.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/TimeUtils.java
@@ -189,11 +189,11 @@ public class TimeUtils {
 
     @SuppressWarnings("unchecked")
     public T getSum() {
-      Double sum = 0.0;
+      double sum = 0.0;
       for (T a : data) {
         sum += a.doubleValue();
       }
-      return (T) sum;
+      return (T) Double.valueOf(sum);
     }
 
     public double getMean() {

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/TimeUtils.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/TimeUtils.java
@@ -187,17 +187,16 @@ public class TimeUtils {
       size = data.size();
     }
 
-    @SuppressWarnings("unchecked")
-    public T getSum() {
+    public double getSum() {
       double sum = 0.0;
       for (T a : data) {
         sum += a.doubleValue();
       }
-      return (T) Double.valueOf(sum);
+      return sum;
     }
 
     public double getMean() {
-      return getSum().doubleValue() / size;
+      return getSum() / size;
     }
 
     public double getVariance() {

--- a/libs/core/src/test/java/com/solarwinds/joboe/core/ContextTest.java
+++ b/libs/core/src/test/java/com/solarwinds/joboe/core/ContextTest.java
@@ -18,9 +18,7 @@ package com.solarwinds.joboe.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.solarwinds.joboe.core.TestReporter.DeserializedEvent;
@@ -39,7 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,131 +45,33 @@ public class ContextTest {
   private static final TestReporter tracingReporter = TestUtils.initTraceReporter();
 
   @AfterEach
-  protected void tearDown() throws Exception {
+  protected void tearDown() {
 
     testSettingsReader.reset();
     tracingReporter.reset();
   }
 
   @Test
-  public void testContext() throws Exception {
-
-    // Clear metadata: it may have been set by a previous test
-    Context.clearMetadata();
-
+  public void testContext() {
     // Make sure we can get metadata from our context:
     final Metadata md = Context.getMetadata();
     assertFalse(md.isValid());
 
     md.randomize();
     assertTrue(md.isValid());
-
-    Metadata md2 = Context.getMetadata();
-    assertSame(md, md2);
-
-    // Make sure we can set IDs:
-    Metadata rndMd = new Metadata();
-    rndMd.randomize();
-
-    Context.setMetadata(rndMd.toHexString());
-    assertEquals(Context.getMetadata().toHexString(), rndMd.toHexString());
-
-    // Verify that the context is inherited in child thread
-    final Metadata parentMD = Context.getMetadata();
-    final AtomicReference<Error> assertionError = new AtomicReference<Error>();
-
-    Thread thr =
-        new Thread(
-            () -> {
-              try {
-                Metadata childMD = Context.getMetadata();
-                assertNotSame(parentMD, childMD); // different object
-                assertEquals(parentMD.toHexString(), childMD.toHexString()); // but same metadata
-                assertTrue(childMD.isValid());
-              } catch (Error e) {
-                assertionError.set(e);
-              }
-            });
-
-    thr.start();
-    thr.join();
-
-    if (assertionError.get() != null) {
-      throw assertionError.get();
-    }
-  }
-
-  @Test
-  public void testInheritContext() throws InterruptedException {
-    Metadata context = Context.getMetadata();
-    context.randomize(); // make a valid context
-
-    TestThread thread;
-
-    thread = new TestThread();
-    thread.start();
-    thread.join();
-
-    assertEquals(
-        context.toHexString(), thread.threadContext.toHexString()); // should have same xtrace id
-    assertNotSame(
-        context,
-        thread
-            .threadContext); // but they should not be the same object, the inherited context should
-    // be a clone
-
-    // test config flag
-    Context.setSkipInheritingContext(true);
-    thread = new TestThread();
-    thread.start();
-    thread.join();
-    Context.setSkipInheritingContext(false);
-
-    assertFalse(thread.threadContext.isValid()); // no context inherited
-    // disable inherit context
-    testSettingsReader.put(
-        new SettingsMockupBuilder()
-            .withFlags(TracingMode.ALWAYS)
-            .withSampleRate(TraceDecisionUtil.SAMPLE_RESOLUTION)
-            .withSettingsArg(SettingsArg.DISABLE_INHERIT_CONTEXT, true)
-            .build());
-    thread = new TestThread();
-    thread.start();
-    thread.join();
-
-    assertFalse(thread.threadContext.isValid()); // no context inherited
-
-    // re-enable inherit context
-    testSettingsReader.put(
-        new SettingsMockupBuilder()
-            .withFlags(TracingMode.ALWAYS)
-            .withSampleRate(TraceDecisionUtil.SAMPLE_RESOLUTION)
-            .build());
-    thread = new TestThread();
-    thread.start();
-    thread.join();
-
-    assertEquals(
-        context.toHexString(), thread.threadContext.toHexString()); // should have same xtrace id
-    assertNotSame(
-        context,
-        thread
-            .threadContext); // but they should not be the same object, the inherited context should
-    // be a clone
   }
 
   @Test
   public void testCreateEventWithContextTtl() throws InterruptedException {
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize(true); // make it a valid context
 
     // warm-up run...as first call can take a few secs (for getting host info)
-    Event event = Context.createEvent();
-    event.report(tracingReporter);
+    Event event = Context.createEventWithContext(metadata);
+    event.report(metadata, tracingReporter);
     tracingReporter.reset();
 
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(); // make it a valid context
+    metadata.randomize(); // make it a valid context
     int newTtl = 2;
     // set to 2 secs
     testSettingsReader.put(
@@ -182,8 +81,8 @@ public class ContextTest {
             .withSettingsArg(SettingsArg.MAX_CONTEXT_AGE, newTtl)
             .build());
 
-    event = Context.createEvent();
-    event.report(tracingReporter); // should be okay
+    event = Context.createEventWithContext(metadata);
+    event.report(metadata, tracingReporter); // should be okay
 
     List<DeserializedEvent> deserializedEvents = tracingReporter.getSentEvents();
     assertEquals(1, deserializedEvents.size()); // ok, since it's within 2 secs
@@ -191,16 +90,17 @@ public class ContextTest {
 
     TimeUnit.SECONDS.sleep(newTtl + 1);
 
-    event = Context.createEvent();
-    event.report(tracingReporter); // not reported as this is more than 2 secs since creation
+    event = Context.createEventWithContext(metadata);
+    event.report(
+        metadata, tracingReporter); // not reported as this is more than 2 secs since creation
     deserializedEvents = tracingReporter.getSentEvents();
     assertTrue(deserializedEvents.isEmpty()); // no events
 
-    Context.clearMetadata(); // ensure reset metadata also reset ttl
-    Context.getMetadata().randomize(); // make it a valid context
+    metadata.randomize(); // make it a valid context
 
-    event = Context.createEvent();
-    event.report(tracingReporter); // this event should now be reported as this is a new metadata
+    event = Context.createEventWithContext(metadata);
+    event.report(
+        metadata, tracingReporter); // this event should now be reported as this is a new metadata
 
     deserializedEvents = tracingReporter.getSentEvents();
     assertEquals(1, deserializedEvents.size());
@@ -210,14 +110,11 @@ public class ContextTest {
 
   @Test
   public void testCreateEventWithMaxEvents() throws InterruptedException {
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
-
     List<DeserializedEvent> deserializedEvents;
 
     // now simulate a max event change
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize(true); // make it a valid context
     int newMaxEvent = 10;
     testSettingsReader.put(
         new SettingsMockupBuilder()
@@ -227,33 +124,30 @@ public class ContextTest {
             .build());
 
     for (int i = 0; i < newMaxEvent; i++) {
-      Event event = Context.createEvent();
-      event.report(tracingReporter);
+      Event event = Context.createEventWithContext(metadata);
+      event.report(metadata, tracingReporter);
     }
 
     deserializedEvents = tracingReporter.getSentEvents();
     assertEquals(newMaxEvent, deserializedEvents.size()); // ok within limit
     tracingReporter.reset();
 
-    Event noopEvent = Context.createEvent(); // exceeding limit
-    noopEvent.report(tracingReporter);
+    Event noopEvent = Context.createEventWithContext(metadata); // exceeding limit
+    noopEvent.report(metadata, tracingReporter);
     deserializedEvents = tracingReporter.getSentEvents();
     tracingReporter.reset();
     assertTrue(deserializedEvents.isEmpty()); // no events
 
-    assertTrue(Context.isValid()); // context should still be valid
-    assertTrue(Context.getMetadata().isSampled()); // and it should still be flagged as sampled
-
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
+    assertTrue(metadata.isSampled()); // and it should still be flagged as sampled
+    metadata.randomize(true); // make it a valid context
 
     ExecutorService threadPool = Executors.newCachedThreadPool();
 
     for (int i = 0; i < newMaxEvent + 50; i++) {
       threadPool.submit(
           () -> {
-            Event event = Context.createEvent();
-            event.report(tracingReporter);
+            Event event = Context.createEventWithContext(metadata);
+            event.report(metadata, tracingReporter);
           });
     }
 
@@ -267,22 +161,20 @@ public class ContextTest {
             .size()); // collected event count should be newMaxEvent (not +1)
     tracingReporter.reset();
 
-    noopEvent = Context.createEvent(); // exceeding limit, this should return a noop
-    noopEvent.report(tracingReporter);
+    noopEvent =
+        Context.createEventWithContext(metadata); // exceeding limit, this should return a noop
+    noopEvent.report(metadata, tracingReporter);
     deserializedEvents = tracingReporter.getSentEvents();
     assertTrue(deserializedEvents.isEmpty()); // no events
   }
 
   @Test
   public void testMaxBacktraces() throws InterruptedException, ExecutionException {
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
-
     List<DeserializedEvent> deserializedEvents;
 
     // now simulate a max event change
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize(true); // make it a valid context
     int newBacktraces = 10;
     testSettingsReader.put(
         new SettingsMockupBuilder()
@@ -292,10 +184,10 @@ public class ContextTest {
             .build());
 
     for (int i = 0; i < newBacktraces; i++) {
-      Event event = Context.createEvent();
+      Event event = Context.createEventWithContext(metadata);
       event.addInfo("Backtrace", "some backtrace");
       event.addInfo("OtherKv", "some value");
-      event.report(tracingReporter);
+      event.report(metadata, tracingReporter);
     }
 
     deserializedEvents = tracingReporter.getSentEvents();
@@ -306,10 +198,10 @@ public class ContextTest {
     }
     tracingReporter.reset();
 
-    Event event = Context.createEvent();
+    Event event = Context.createEventWithContext(metadata);
     event.addInfo("Backtrace", "some backtrace"); // exceeding limit
     event.addInfo("OtherKv", "some value"); // this should still get through
-    event.report(tracingReporter);
+    event.report(metadata, tracingReporter);
 
     deserializedEvents = tracingReporter.getSentEvents();
     assertEquals(1, deserializedEvents.size());
@@ -318,20 +210,18 @@ public class ContextTest {
     assertEquals("some value", deseralizedEvent.getSentEntries().get("OtherKv"));
     tracingReporter.reset();
 
-    Context.clearMetadata(); // this triggers creation of new metadata
-    Context.getMetadata().randomize(true); // make it a valid context
-
+    metadata.randomize(true); // make it a valid context
     ExecutorService threadPool = Executors.newCachedThreadPool();
 
-    List<Future<?>> futures = new ArrayList<Future<?>>();
+    List<Future<?>> futures = new ArrayList<>();
     for (int i = 0; i < newBacktraces + 10; i++) {
       futures.add(
           threadPool.submit(
               () -> {
-                Event event1 = Context.createEvent();
+                Event event1 = Context.createEventWithContext(metadata);
                 event1.addInfo("Backtrace", "some backtrace"); // 10 backtraces will not be reported
                 event1.addInfo("OtherKv", "some value");
-                event1.report(tracingReporter);
+                event1.report(metadata, tracingReporter);
               }));
     }
 
@@ -353,14 +243,5 @@ public class ContextTest {
 
     tracingReporter.reset();
     assertEquals(newBacktraces, backTraceCollected);
-  }
-
-  private static class TestThread extends Thread {
-    private Metadata threadContext;
-
-    @Override
-    public void run() {
-      threadContext = Context.getMetadata();
-    }
   }
 }

--- a/libs/core/src/test/java/com/solarwinds/joboe/core/EventImplTest.java
+++ b/libs/core/src/test/java/com/solarwinds/joboe/core/EventImplTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -60,14 +61,14 @@ public class EventImplTest {
   }
 
   @AfterEach
-  protected void tearDown() throws Exception {
+  protected void tearDown() {
+    Assertions.assertNotNull(reporter);
     reporter.reset();
-    Context.clearMetadata();
   }
 
   /*  Test that events can be sent and decoded, using a mock sender. */
   @Test
-  public void testLocalSendEvent() throws Exception {
+  public void testLocalSendEvent() {
 
     // Metadata for the context:
     Metadata md = new Metadata();
@@ -193,16 +194,14 @@ public class EventImplTest {
     assertEquals(1, reporter.getSentEvents().size());
   }
 
-  /**
-   * Over-sized event with a large KV
-   *
-   * @throws InvalidConfigException
-   */
+  /** Over-sized event with a large KV */
   @Test
-  public void testOversizedEvent1() throws InvalidConfigException {
+  public void testOversizedEvent1() {
     String bigValue = new String(new char[1000000]);
 
-    Event testEvent = startTrace();
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
 
     testEvent.addInfo("key1", bigValue);
     testEvent.addInfo("key2", new String[] {bigValue, bigValue, bigValue});
@@ -212,12 +211,12 @@ public class EventImplTest {
     testEvent.addInfo("key6", new String[] {"hi"});
     testEvent.addInfo("key7", new Object[] {1, bigValue});
 
-    Metadata testEdge = new Metadata(Context.getMetadata());
+    Metadata testEdge = new Metadata(md);
     testEdge.randomizeOpID();
     testEvent.addEdge(testEdge.toHexString());
 
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -250,14 +249,16 @@ public class EventImplTest {
    */
   @Test
   public void testOversizedEvent2() throws InvalidConfigException {
-    Event testEvent = startTrace();
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
 
     for (int i = 0; i < 10000; i++) {
       testEvent.addInfo(String.valueOf(i), i);
     }
 
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -290,11 +291,13 @@ public class EventImplTest {
       hugeArray[i] = 0;
     }
 
-    Event testEvent = startTrace();
-    testEvent.addInfo("HugeArray", hugeArray);
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
 
+    testEvent.addInfo("HugeArray", hugeArray);
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -325,11 +328,13 @@ public class EventImplTest {
       longString.append(i);
     }
 
-    Event testEvent = startTrace();
-    testEvent.addInfo("LongString", longString.toString());
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
 
+    testEvent.addInfo("LongString", longString.toString());
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -361,13 +366,16 @@ public class EventImplTest {
     }
     final String longPrefix = longString.toString();
 
-    Event testEvent = startTrace();
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
+
     for (int i = 0; i < 100; i++) {
       testEvent.addInfo(longPrefix + i, longPrefix + 1);
     }
 
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -399,14 +407,16 @@ public class EventImplTest {
       map.put(PREFIX + i, PREFIX);
     }
 
-    Event testEvent = startTrace();
-    testEvent.addInfo("large-map", map);
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
 
+    testEvent.addInfo("large-map", map);
     testEvent.addInfo("k1", 1); // these 2 should still make it
     testEvent.addInfo("k2", "2");
 
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -441,14 +451,16 @@ public class EventImplTest {
       list.add(PREFIX + i);
     }
 
-    Event testEvent = startTrace();
-    testEvent.addInfo("long-list", list);
+    Metadata md = new Metadata();
+    md.randomize(true);
+    Event testEvent = Context.createEventWithContext(md, false);
 
+    testEvent.addInfo("long-list", list);
     testEvent.addInfo("k1", 1); // these 2 should still make it
     testEvent.addInfo("k2", "2");
 
     TestReporter reporter = ReporterFactory.getInstance().createTestReporter();
-    testEvent.report(reporter);
+    testEvent.report(md, reporter);
 
     // Decode what was "sent":
     ByteBuffer buf = ByteBuffer.wrap(reporter.getLastSent()).order(ByteOrder.LITTLE_ENDIAN);
@@ -471,21 +483,22 @@ public class EventImplTest {
 
   @Test
   public void testAsyncByMarkedEvent() {
-    Context.getMetadata().randomize(true);
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize(true);
 
-    Event event = Context.createEvent();
+    Event event = Context.createEventWithContext(metadata);
     event.addInfo(
         "Layer", "test",
         "Label", "entry");
     event.setAsync();
-    event.report(reporter);
+    event.report(event.metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo(
         "Layer", "test",
         "Label", "exit");
     event.setAsync();
-    event.report(reporter);
+    event.report(event.metadata, reporter);
 
     for (DeserializedEvent deserializedEvent : reporter.getSentEvents()) {
       assertEquals(true, deserializedEvent.getSentEntries().get(Constants.XTR_ASYNC_KEY));
@@ -494,43 +507,43 @@ public class EventImplTest {
 
   @Test
   public void testAsyncByMarkedMetadata() {
-    Context.getMetadata().randomize(true);
-    Context.getMetadata().setIsAsync(true);
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize(true);
+    metadata.setIsAsync(true);
 
-    Event event = Context.createEvent();
+    Event event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test", "Label", "entry");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test-nested", "Label", "entry");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test-nested", "Label", "exit");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test", "Label", "exit");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test", "Label", "entry");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test-nested", "Label", "entry");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test-nested", "Label", "exit");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
-    event = Context.createEvent();
+    event = Context.createEventWithContext(metadata);
     event.addInfo("Layer", "test", "Label", "exit");
-    event.report(reporter);
+    event.report(metadata, reporter);
 
     List<DeserializedEvent> deserializedEvents = reporter.getSentEvents();
-
     assertEquals(8, deserializedEvents.size());
 
     // only the first (0) and the fifth (4)
@@ -551,12 +564,5 @@ public class EventImplTest {
     assertEquals(
         "2BA6A6D97A748BFC9F91A4DC46A0D15BBB00000000B6968E14AC09A25A00",
         EventImpl.w3cContextToXTrace("00-a6a6d97a748bfc9f91a4dc46a0d15bbb-b6968e14ac09a25a-00"));
-  }
-
-  private Event startTrace() {
-    Metadata md = new Metadata();
-    md.randomize(true);
-    Context.setMetadata(md);
-    return Context.createEventWithContext(md, false);
   }
 }

--- a/libs/core/src/test/java/com/solarwinds/joboe/core/TestReporterTest.java
+++ b/libs/core/src/test/java/com/solarwinds/joboe/core/TestReporterTest.java
@@ -32,19 +32,23 @@ public class TestReporterTest {
   }
 
   @Test
-  public void testReporterSameThread() throws InvalidConfigException {
+  public void testReporterSameThread() {
     final TestReporter threadLocalReporter = ReporterFactory.getInstance().createTestReporter(true);
     final TestReporter nonThreadLocalReporter =
         ReporterFactory.getInstance().createTestReporter(false);
 
     Event event;
+    Metadata md = new Metadata();
+    md.randomize(true);
 
-    event = startTrace();
-    event.report(threadLocalReporter);
+    event = Context.createEventWithContext(md, false);
+    event.report(md, threadLocalReporter);
 
-    event = startTrace();
-    event.report(nonThreadLocalReporter);
+    md = new Metadata();
+    md.randomize(true);
+    event = Context.createEventWithContext(md, false);
 
+    event.report(md, nonThreadLocalReporter);
     assertEquals(1, threadLocalReporter.getSentEvents().size());
     assertEquals(1, nonThreadLocalReporter.getSentEvents().size());
   }
@@ -59,12 +63,16 @@ public class TestReporterTest {
         new Thread(
             () -> {
               Event event;
+              Metadata md = new Metadata();
+              md.randomize(true);
 
-              event = startTrace();
-              event.report(threadLocalReporter);
+              event = Context.createEventWithContext(md, false);
+              event.report(md, threadLocalReporter);
 
-              event = startTrace();
-              event.report(nonThreadLocalReporter);
+              md = new Metadata();
+              md.randomize(true);
+              event = Context.createEventWithContext(md, false);
+              event.report(md, nonThreadLocalReporter);
             });
 
     thread.start();
@@ -74,12 +82,5 @@ public class TestReporterTest {
         0,
         threadLocalReporter.getSentEvents().size()); // different thread, should not get the event
     assertEquals(1, nonThreadLocalReporter.getSentEvents().size());
-  }
-
-  private Event startTrace() {
-    Metadata md = new Metadata();
-    md.randomize(true);
-    Context.setMetadata(md);
-    return Context.createEventWithContext(md, false);
   }
 }

--- a/libs/core/src/test/java/com/solarwinds/joboe/core/rpc/RpcClientTest.java
+++ b/libs/core/src/test/java/com/solarwinds/joboe/core/rpc/RpcClientTest.java
@@ -137,13 +137,14 @@ public abstract class RpcClientTest {
 
   private static List<Event> generateTestEvents() {
     List<Event> testEvents = new ArrayList<Event>();
-    Context.getMetadata().randomize();
-    Event entryEvent = Context.createEvent();
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize();
+    Event entryEvent = Context.createEventWithContext(metadata);
     entryEvent.addInfo("Layer", "test-thrift");
     entryEvent.addInfo("Label", "entry");
     testEvents.add(entryEvent);
 
-    Event exitEvent = Context.createEvent();
+    Event exitEvent = Context.createEventWithContext(metadata);
     exitEvent.addInfo("Layer", "test-thrift");
     exitEvent.addInfo("Label", "exit");
     testEvents.add(exitEvent);
@@ -152,8 +153,9 @@ public abstract class RpcClientTest {
   }
 
   private static Event generateBigEvent() {
-    Context.getMetadata().randomize();
-    Event testEvent = Context.createEvent();
+    Metadata metadata = Context.getMetadata();
+    metadata.randomize();
+    Event testEvent = Context.createEventWithContext(metadata);
     for (int i = 0; i < 100; i++) { // each event is around 100 kb
       testEvent.addInfo(String.valueOf(i), new byte[1024]);
     }
@@ -874,8 +876,9 @@ public abstract class RpcClientTest {
       List<Future<Result>> futures = new ArrayList<Future<Result>>();
       List<Event> sentEvents = new ArrayList<Event>();
       for (int i = 0; i < 100; i++) {
-        Context.getMetadata().randomize();
-        Event entryEvent = Context.createEvent();
+        Metadata metadata = Context.getMetadata();
+        metadata.randomize();
+        Event entryEvent = Context.createEventWithContext(metadata);
         entryEvent.addInfo("Layer", "test-" + i);
         entryEvent.addInfo("Label", "info");
 

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/Metadata.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/Metadata.java
@@ -86,11 +86,10 @@ public class Metadata {
 
   public Metadata(SpanContext spanContext) {
     initialize();
-    if (spanContext.isValid()) {
-      System.arraycopy(spanContext.getTraceIdBytes(), 0, this.taskID, 0, Constants.TASK_ID_LEN);
-      System.arraycopy(spanContext.getSpanIdBytes(), 0, this.opID, 0, Constants.OP_ID_LEN);
-      this.flags = spanContext.getTraceFlags().asByte();
-    }
+    System.arraycopy(spanContext.getTraceIdBytes(), 0, this.taskID, 0, Constants.TASK_ID_LEN);
+    System.arraycopy(spanContext.getSpanIdBytes(), 0, this.opID, 0, Constants.OP_ID_LEN);
+
+    flags = spanContext.getTraceFlags().asByte();
   }
 
   public Metadata(Metadata toClone) {

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/SamplingConfiguration.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/SamplingConfiguration.java
@@ -17,10 +17,12 @@
 package com.solarwinds.joboe.sampling;
 
 import lombok.Builder;
+import lombok.ToString;
 import lombok.Value;
 
 @Value
 @Builder
+@ToString
 public class SamplingConfiguration {
   @Builder.Default int ttl = 1_200_000; // 20 minutes by default, in unit of millisecond;
 

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/SettingsArg.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/SettingsArg.java
@@ -87,7 +87,7 @@ public abstract class SettingsArg<T> {
    * @param byteBuffer
    * @return
    */
-  public abstract T readValue(ByteBuffer byteBuffer);
+  public abstract T readFromByteBuffer(ByteBuffer byteBuffer);
 
   /** Converts the given {@link Object} to T */
   public abstract T readValue(Object object);
@@ -148,7 +148,7 @@ public abstract class SettingsArg<T> {
     }
 
     @Override
-    public Double readValue(ByteBuffer byteBuffer) {
+    public Double readFromByteBuffer(ByteBuffer byteBuffer) {
       try {
         return byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getDouble();
       } catch (BufferUnderflowException e) {
@@ -196,7 +196,7 @@ public abstract class SettingsArg<T> {
     }
 
     @Override
-    public Integer readValue(ByteBuffer byteBuffer) {
+    public Integer readFromByteBuffer(ByteBuffer byteBuffer) {
       try {
         return byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getInt();
       } catch (BufferUnderflowException e) {
@@ -244,7 +244,7 @@ public abstract class SettingsArg<T> {
     }
 
     @Override
-    public Boolean readValue(ByteBuffer byteBuffer) {
+    public Boolean readFromByteBuffer(ByteBuffer byteBuffer) {
       try {
         int value = byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getInt();
         return value != 0; // any non-zero is considered as True
@@ -290,7 +290,7 @@ public abstract class SettingsArg<T> {
     }
 
     @Override
-    public byte[] readValue(ByteBuffer byteBuffer) {
+    public byte[] readFromByteBuffer(ByteBuffer byteBuffer) {
       try {
         byte[] value = new byte[byteBuffer.remaining()];
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN).get(value);

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/TraceConfigs.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/TraceConfigs.java
@@ -22,12 +22,14 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import lombok.ToString;
 
 /**
  * Container that stores {@link TraceConfig} mapped by URL
  *
  * @author pluk
  */
+@ToString
 public class TraceConfigs implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/libs/sampling/src/test/java/com/solarwinds/joboe/sampling/SettingsArgTest.java
+++ b/libs/sampling/src/test/java/com/solarwinds/joboe/sampling/SettingsArgTest.java
@@ -35,7 +35,7 @@ public class SettingsArgTest {
     ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
     buffer.putDouble(1.23);
     buffer.flip();
-    assertEquals(1.23, arg.readValue(buffer));
+    assertEquals(1.23, arg.readFromByteBuffer(buffer));
   }
 
   @Test
@@ -45,7 +45,7 @@ public class SettingsArgTest {
     ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
     buffer.putInt(3);
     buffer.flip();
-    assertEquals(3, (int) arg.readValue(buffer));
+    assertEquals(3, (int) arg.readFromByteBuffer(buffer));
   }
 
   @Test
@@ -55,12 +55,12 @@ public class SettingsArgTest {
     ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
     buffer.putInt(1); // boolean uses int in bytebuffer (binary)
     buffer.flip();
-    assertEquals(true, arg.readValue(buffer));
+    assertEquals(true, arg.readFromByteBuffer(buffer));
 
     buffer = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
     buffer.putInt(0); // boolean uses int in bytebuffer (binary)
     buffer.flip();
-    assertEquals(false, arg.readValue(buffer));
+    assertEquals(false, arg.readFromByteBuffer(buffer));
   }
 
   @Test
@@ -104,6 +104,6 @@ public class SettingsArgTest {
             .order(ByteOrder.LITTLE_ENDIAN); // 4 bytes will trigger buffer underflow
     buffer.putInt(3);
     buffer.flip();
-    assertNull(arg.readValue(buffer)); // should just give null
+    assertNull(arg.readFromByteBuffer(buffer)); // should just give null
   }
 }

--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -133,9 +133,8 @@ function verify_that_span_data_is_persisted() {
                     for (let k = 0; k < properties.length; k++) {
                         const property = properties[k]
                         check(property, {"mvc handler name is added": prop => prop.key === "HandlerName"})
-                        check(property, {"code profiling": prop => prop.key === "NewFrames"})
-
                         check(property, {"trigger trace": prop => prop.key === "TriggeredTrace"})
+
                         if (property.key === "PDKeys") {
                             check(property, {"xtrace-options is added to root span": prop => prop.value === "{check-id=123, lo=se}"})
                             found = true
@@ -153,6 +152,65 @@ function verify_that_span_data_is_persisted() {
 
     }
 
+}
+
+function verify_profile() {
+    const newOwner = names.randomOwner();
+    let retryCount = Number.parseInt(`${__ENV.SWO_RETRY_COUNT}`) || 1000;
+    for (; retryCount > 0; retryCount--) {
+        const newOwnerResponse = http.post(`${baseUri}/owners`, JSON.stringify(newOwner),
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    "x-trace-options": "trigger-trace;custom-info=chubi;sw-keys=lo:se,check-id:123"
+                }
+            });
+
+        const traceContext = newOwnerResponse.headers['X-Trace']
+        const [_, __, ___, flag] = traceContext.split("-")
+        console.log("Trace context -> ", traceContext)
+        if ((parseInt(flag, 16) & 1) === 0) continue;
+
+        const endTime = Date.now();
+        const startTime = endTime - 10 * 60 * 1000;
+        const profileSpanQueryPayload = {
+            "operationName": "getSearchedTraceRequests",
+            "variables": {
+                "searchQuery": "sw.profile.spans:1",
+                "orderBy": {
+                    "direction": "DESC",
+                    "sort": "TIME"
+                },
+                "first": 15,
+                "timeFilter": {
+                    "startTime": `${startTime}`,
+                    "endTime": `${endTime}`
+                },
+                "serviceNames": ["java-apm-smoke-test","java-apm-smoke-test-webmvc"]
+            },
+            "query": "query getSearchedTraceRequests($first: Int, $serviceNames: [String!], $timeFilter: TimeRangeInput!, $orderBy: TraceRequestItemsOrderBy!, $searchQuery: String!) {\n  trace {\n    requests(\n      context: {serviceNames: $serviceNames}\n      search: {query: $searchQuery, timeRange: $timeFilter}\n      paging: {first: $first}\n      orderBy: $orderBy\n    ) {\n      totalCount\n      pageInfo {\n        startCursor\n        endCursor\n        hasPreviousPage\n        hasNextPage\n        __typename\n      }\n      edges {\n        node {\n          id\n          traceId\n          spanId\n          time\n          transaction\n          httpMethod\n          httpStatus\n          service\n          serviceEntityId\n          websiteEntityName\n          awsLambdaEntityName\n          awsLambdaEntityId\n          hostEntityName\n          hostEntityId\n          websiteId\n          duration {\n            value\n            units\n            __typename\n          }\n          __typename\n        }\n        cursor\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n"
+        }
+
+        for (; retryCount > 0; retryCount--) {
+            let profileResponse = http.post(`${__ENV.SWO_HOST_URL}/common/graphql`, JSON.stringify(profileSpanQueryPayload),
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Cookie': `${__ENV.SWO_COOKIE}`,
+                        'X-Csrf-Token': `${__ENV.SWO_XSR_TOKEN}`
+                    }
+                });
+
+            profileResponse = JSON.parse(profileResponse.body)
+            if (profileResponse['errors']) {
+              console.log("Error -> Profile spans response:", JSON.stringify(profileResponse))
+              continue
+            }
+
+            const {data: {trace: {requests: {edges}}}} = profileResponse
+            check(edges, {"code profiling": prop => prop.length > 0})
+        }
+    }
 }
 
 function verify_that_span_data_is_persisted_0() {
@@ -206,9 +264,8 @@ function verify_that_span_data_is_persisted_0() {
 
                     for (let k = 0; k < properties.length; k++) {
                         const property = properties[k]
-
                         check(property, {"trigger trace": prop => prop.key === "TriggeredTrace"})
-                        check(property, {"code profiling": prop => prop.key === "NewFrames"})
+
                         if (property.key === "sw.transaction") {
                             check(property, {"custom transaction name": prop => prop.value === transactionName})
                             return;
@@ -683,5 +740,6 @@ export default function () {
     silence(verify_that_span_data_is_persisted)
     silence(verify_that_trace_is_persisted)
     silence(verify_distributed_trace)
+    silence(verify_profile)
   }
 };

--- a/smoke-tests/k6/basic.js
+++ b/smoke-tests/k6/basic.js
@@ -208,7 +208,9 @@ function verify_profile() {
             }
 
             const {data: {trace: {requests: {edges}}}} = profileResponse
-            check(edges, {"code profiling": prop => prop.length > 0})
+            if (check(edges, {"code profiling": prop => prop.length > 0})) {
+                return;
+            }
         }
     }
 }

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTest.java
@@ -165,7 +165,6 @@ public class SmokeTest {
     }
 
     @Test
-    @Disabled
     void assertCodeProfiling()  throws IOException {
         String resultJson = new String(Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
         double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['code profiling'].passes");

--- a/smoke-tests/src/test/java/com/solarwinds/SmokeTestV2.java
+++ b/smoke-tests/src/test/java/com/solarwinds/SmokeTestV2.java
@@ -157,7 +157,6 @@ public class SmokeTestV2 {
     }
 
     @Test
-    @Disabled
     void assertCodeProfiling() throws IOException {
         String resultJson = new String(Files.readAllBytes(namingConventions.local.k6Results(Configs.E2E.config.agents().get(0))));
         double passes = ResultsCollector.read(resultJson, "$.root_group.checks.['code profiling'].passes");

--- a/smoke-tests/src/test/java/com/solarwinds/agents/Agent.java
+++ b/smoke-tests/src/test/java/com/solarwinds/agents/Agent.java
@@ -42,6 +42,8 @@ public class Agent {
   public Agent(String name, String description, String url) {
     this(name, description, url, Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true",
             "-Dotel.java.experimental.span-stacktrace.min.duration=0ms",
+            "-Dsw.apm.profiler.enabled=true",
+            "-Dsw.apm.profiler.interval=10",
             "-Dsw.apm.span.stacktrace.filters=thread.id,os.description,http.request.method"));
   }
 


### PR DESCRIPTION
## Summary

Remove dead code from the `Context` class and address code scanning findings across core and sampling modules. The `Context` class no longer maintains its own thread-local metadata state — it now delegates entirely to the current OpenTelemetry `SpanContext`. Code profiling smoke tests are re-enabled with a new dedicated verification approach.

## Dead Code Removal — `Context` class

- Removed the `InheritableThreadLocal<Metadata>` and all associated thread-local context management (`setMetadata`, `clearMetadata`, `setSkipInheritingContext`, `skipInheritingContextThreadLocal`)
- Removed the `SettingsArg.DISABLE_INHERIT_CONTEXT` listener that toggled context inheritance behavior
- Removed unused factory methods: `createEvent()`, `createEventWithID()`, `createEventWithIDAndContext()`, `createEventWithGeneratedMetadata()`
- `getMetadata()` now simply constructs a `Metadata` from the current OTel `Span.current().getSpanContext()` instead of reading from thread-local storage
- Removed the `Event.report(EventReporter)` single-arg overload (and its implementations in `EventImpl` and `NoopEvent`) — callers now always pass the `Metadata` explicitly

## Code Scanning Fixes

- `Metadata(SpanContext)` constructor: removed the `isValid()` guard — the caller is responsible for validity; this avoids leaving fields in an inconsistent half-initialized state
- `TimeUtils.getSum()`: replaced autoboxing of primitive `Double` → `double` and explicit `Double.valueOf()` to avoid unnecessary boxing flagged by code scanning
- `SolarwindsProfilingSpanProcessor`: inlined a single-use local variable (`spanContext`) to reduce scope
- `ServerHostInfoReader.getHostId()`: removed the `Context.clearMetadata()`/`setMetadata()` save-restore pattern that was guarding against accidental tracing during init — no longer needed since `Context` doesn't hold mutable state
- Removed unused `getDockerContainerId()` method and `HOSTNAME_SEPARATOR` constant from `ServerHostInfoReader`
- Replaced raw type diamond operators (`new HashMap<String, String>()` → `new HashMap<>()`) and `System.getProperty("line.separator")` → `System.lineSeparator()`
- Cleaned up empty `@param`/`@return` javadoc tags

## `SettingsArg` Rename

- Renamed the `readValue(ByteBuffer)` method to `readFromByteBuffer(ByteBuffer)` across all `SettingsArg` subtypes to disambiguate it from the `readValue(Object)` overload

## Observability Additions

- Added `@ToString` (Lombok) to `SamplingConfiguration` and `TraceConfigs` for better logging/debugging visibility

## Smoke Test — Code Profiling

- Re-enabled the `assertCodeProfiling` test (removed `@Disabled`) in both `SmokeTest` and `SmokeTestV2`
- Added a new `verify_profile` function in the k6 script that queries the SWO GraphQL API for spans with `sw.profile.spans:1`, replacing the previous inline property check (`NewFrames` key)
- Enabled the profiler in the smoke test agent config (`-Dsw.apm.profiler.enabled=true`, `-Dsw.apm.profiler.interval=10`)

## Test Updates

- All tests updated to use explicit `Metadata` instances and `createEventWithContext(metadata)` / `report(metadata, reporter)` instead of the removed `Context.createEvent()` / `event.report(reporter)` patterns
- Removed `testInheritContext` test and `TestThread` helper class since thread-local context inheritance no longer exists
- Removed `startTrace()` helper methods from `EventImplTest` and `TestReporterTest` — replaced with inline metadata setup


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
