### PR TITLE
New - declarative config parity and deprecated `monitor.*` config removal

### DIFF
--- a/agent-lambda/script/solarwinds-apm-config.json
+++ b/agent-lambda/script/solarwinds-apm-config.json
@@ -1,6 +1,5 @@
 {
   "agent.logging": "info",
-  "monitor.jmx.enable": false,
   "profiler": {
     "enabled": false,
     "excludePackages": [

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/CustomConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/CustomConfigCustomizerProvider.java
@@ -39,9 +39,8 @@ public class CustomConfigCustomizerProvider implements DeclarativeConfigurationC
     customizer.addModelCustomizer(
         configurationModel -> {
           TracerProviderModel tracerProvider = configurationModel.getTracerProvider();
-          if (tracerProvider == null) {
-            tracerProvider = new TracerProviderModel();
-            configurationModel.withTracerProvider(tracerProvider);
+          if (tracerProvider != null) {
+            addProcessors(tracerProvider);
           }
 
           ResourceModel resourceModel = configurationModel.getResource();
@@ -51,7 +50,6 @@ public class CustomConfigCustomizerProvider implements DeclarativeConfigurationC
           }
 
           addResourceDetector(resourceModel);
-          addProcessors(tracerProvider);
           return configurationModel;
         });
   }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/CustomConfigCustomizerProviderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/CustomConfigCustomizerProviderTest.java
@@ -18,6 +18,7 @@ package com.solarwinds.opentelemetry.extensions.config.provider;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
@@ -58,7 +59,7 @@ class CustomConfigCustomizerProviderTest {
           .thenReturn(true);
 
       OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
-          new OpenTelemetryConfigurationModel();
+          new OpenTelemetryConfigurationModel().withTracerProvider(new TracerProviderModel());
 
       doNothing()
           .when(declarativeConfigurationCustomizerMock)
@@ -88,7 +89,7 @@ class CustomConfigCustomizerProviderTest {
           .thenReturn(false);
 
       OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
-          new OpenTelemetryConfigurationModel();
+          new OpenTelemetryConfigurationModel().withTracerProvider(new TracerProviderModel());
 
       doNothing()
           .when(declarativeConfigurationCustomizerMock)
@@ -131,6 +132,29 @@ class CustomConfigCustomizerProviderTest {
               .getDetectionDevelopment()
               .getDetectors()
               .isEmpty());
+    }
+  }
+
+  @Test
+  void processorsNotAddedWhenTracerProviderAbsent() {
+    try (MockedStatic<JavaRuntimeVersionChecker> javaRuntimeVersionCheckerMockedStatic =
+        mockStatic(JavaRuntimeVersionChecker.class)) {
+      javaRuntimeVersionCheckerMockedStatic
+          .when(JavaRuntimeVersionChecker::isJdkVersionSupported)
+          .thenReturn(true);
+
+      OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+          new OpenTelemetryConfigurationModel();
+
+      doNothing()
+          .when(declarativeConfigurationCustomizerMock)
+          .addModelCustomizer(functionArgumentCaptor.capture());
+
+      tested.customize(declarativeConfigurationCustomizerMock);
+      functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+      assertNull(openTelemetryConfigurationModel.getTracerProvider());
+      assertNotNull(openTelemetryConfigurationModel.getResource());
     }
   }
 }

--- a/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigGroup.java
+++ b/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigGroup.java
@@ -23,6 +23,5 @@ package com.solarwinds.joboe.config;
  */
 public enum ConfigGroup {
   AGENT,
-  MONITOR,
   PROFILER
 }

--- a/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigProperty.java
+++ b/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigProperty.java
@@ -82,7 +82,9 @@ public enum ConfigProperty {
       ConfigGroup.AGENT,
       String.class),
   AGENT_LOG_FILE(
-      new ConfigKey(null, EnvPrefix.PRODUCT + "JAVA_LOG_FILE"), ConfigGroup.AGENT, String.class),
+      new ConfigKey("agent.javaLogFile", EnvPrefix.PRODUCT + "JAVA_LOG_FILE"),
+      ConfigGroup.AGENT,
+      String.class),
   AGENT_COLLECTOR(
       new ConfigKey("agent.collector", EnvPrefix.PRODUCT + "COLLECTOR"),
       ConfigGroup.AGENT,
@@ -146,19 +148,6 @@ public enum ConfigProperty {
       new ConfigKey("agent.sqlTagDatabases", EnvPrefix.PRODUCT + "SQL_TAG_DATABASES"),
       ConfigGroup.AGENT,
       String.class),
-  MONITOR_JMX_SCOPES(new ConfigKey("monitor.jmx.scopes"), ConfigGroup.MONITOR, String.class),
-  MONITOR_JMX_ENABLE(new ConfigKey("monitor.jmx.enable"), ConfigGroup.MONITOR, Boolean.class),
-  MONITOR_JMX_MAX_ENTRY(new ConfigKey("monitor.jmx.maxEntry"), ConfigGroup.MONITOR, Integer.class),
-  MONITOR_METRICS_FLUSH_INTERVAL(
-      new ConfigKey(null, EnvPrefix.PRODUCT + "METRICS_FLUSH_INTERVAL"),
-      ConfigGroup.MONITOR,
-      Integer.class),
-
-  MONITOR_SPAN_METRICS_ENABLE(
-      new ConfigKey("monitor.spanMetrics.enable", EnvPrefix.PRODUCT + "SPAN_METRICS_ENABLE"),
-      ConfigGroup.MONITOR,
-      Boolean.class),
-
   PROFILER(new ConfigKey("profiler"), ConfigGroup.PROFILER, String.class),
   PROFILER_ENABLED_ENV_VAR(
       new ConfigKey(null, EnvPrefix.PRODUCT + "PROFILER_ENABLED"),

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/SqlQueryMaxLengthParser.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/SqlQueryMaxLengthParser.java
@@ -1,0 +1,49 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.opentelemetry.extensions.config.parser.yaml;
+
+import com.google.auto.service.AutoService;
+import com.solarwinds.joboe.config.ConfigParser;
+import com.solarwinds.joboe.config.InvalidConfigException;
+import com.solarwinds.opentelemetry.extensions.Constants;
+import com.solarwinds.opentelemetry.extensions.config.parser.json.RangeValidationParser;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+
+@SuppressWarnings("rawtypes")
+@AutoService(ConfigParser.class)
+public class SqlQueryMaxLengthParser implements ConfigParser<DeclarativeConfigProperties, Integer> {
+  private static final String CONFIG_KEY = "agent.sqlQueryMaxLength";
+
+  private static final RangeValidationParser<Integer> RANGE_VALIDATOR =
+      new RangeValidationParser<>(
+          Constants.MAX_SQL_QUERY_LENGTH_LOWER_LIMIT, Constants.MAX_SQL_QUERY_LENGTH_UPPER_LIMIT);
+
+  @Override
+  public Integer convert(DeclarativeConfigProperties declarativeConfigProperties)
+      throws InvalidConfigException {
+    Integer value = declarativeConfigProperties.getInt(CONFIG_KEY);
+    if (value == null) {
+      return null;
+    }
+    return RANGE_VALIDATOR.convert(value);
+  }
+
+  @Override
+  public String configKey() {
+    return CONFIG_KEY;
+  }
+}

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/TriggerTraceParser.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/TriggerTraceParser.java
@@ -1,0 +1,37 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.opentelemetry.extensions.config.parser.yaml;
+
+import com.google.auto.service.AutoService;
+import com.solarwinds.joboe.config.ConfigParser;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+
+@SuppressWarnings("rawtypes")
+@AutoService(ConfigParser.class)
+public class TriggerTraceParser implements ConfigParser<DeclarativeConfigProperties, Boolean> {
+  private static final String CONFIG_KEY = "agent.triggerTrace";
+
+  @Override
+  public Boolean convert(DeclarativeConfigProperties declarativeConfigProperties) {
+    return declarativeConfigProperties.getBoolean(CONFIG_KEY, true);
+  }
+
+  @Override
+  public String configKey() {
+    return CONFIG_KEY;
+  }
+}

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/UrlSampleRateConfigParser.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/UrlSampleRateConfigParser.java
@@ -75,9 +75,7 @@ public class UrlSampleRateConfigParser
           urlSampleRate.getStructured(url, DeclarativeConfigProperties.empty());
       TraceConfig traceConfig = extractConfig(urlConfig, declarativeConfigProperties);
 
-      if (traceConfig != null) {
-        result.put(new StringPatternMatcher(pattern), traceConfig);
-      }
+      result.put(new StringPatternMatcher(pattern), traceConfig);
     }
 
     return new TraceConfigs(result);

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
@@ -81,28 +81,31 @@ public class SharedConfigCustomizerProvider implements DeclarativeConfigurationC
           if (meterProvider == null) {
             meterProvider = new MeterProviderModel();
             configurationModel.withMeterProvider(meterProvider);
+            try {
+              ConfigManager.setConfig(ConfigProperty.AGENT_EXPORT_METRICS_ENABLED, false);
+            } catch (InvalidConfigException ignore) {
+            }
           }
-
-          if (tracerProvider == null) {
-            tracerProvider = new TracerProviderModel();
-            configurationModel.withTracerProvider(tracerProvider);
-          }
-
-          if (loggerProvider == null) {
-            loggerProvider = new LoggerProviderModel();
-            configurationModel.withLoggerProvider(loggerProvider);
-          }
-
-          addSampler(tracerProvider);
-          addProcessors(tracerProvider);
           addMetricExporter(configurationModel);
 
-          addLogExporter(configurationModel);
-          addSpanExporter(configurationModel);
-          PropagatorModel propagatorModel = new PropagatorModel();
+          if (tracerProvider != null) {
+            addSampler(tracerProvider);
+            addProcessors(tracerProvider);
+
+            addSpanExporter(configurationModel);
+          }
+
+          if (loggerProvider != null) {
+            addLogExporter(configurationModel);
+          }
+
+          PropagatorModel propagatorModel = configurationModel.getPropagator();
+          if (propagatorModel == null) {
+            propagatorModel = new PropagatorModel();
+            configurationModel.withPropagator(propagatorModel);
+          }
 
           addContextPropagators(propagatorModel);
-          configurationModel.withPropagator(propagatorModel);
           return configurationModel;
         });
   }
@@ -156,9 +159,15 @@ public class SharedConfigCustomizerProvider implements DeclarativeConfigurationC
   }
 
   private void addContextPropagators(PropagatorModel model) {
-    model.withCompositeList(
-        String.format(
-            "tracecontext,baggage,%s", ContextPropagatorComponentProvider.COMPONENT_NAME));
+    String compositeList = model.getCompositeList();
+    if (compositeList != null) {
+      model.withCompositeList(
+          String.format("%s,%s", compositeList, ContextPropagatorComponentProvider.COMPONENT_NAME));
+    } else {
+      model.withCompositeList(
+          String.format(
+              "tracecontext,baggage,%s", ContextPropagatorComponentProvider.COMPONENT_NAME));
+    }
   }
 
   private void addSpanExporter(OpenTelemetryConfigurationModel model) {

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/SqlQueryMaxLengthParserTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/SqlQueryMaxLengthParserTest.java
@@ -1,0 +1,83 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.opentelemetry.extensions.config.parser.yaml;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.solarwinds.joboe.config.InvalidConfigException;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class SqlQueryMaxLengthParserTest {
+  private static DeclarativeConfigProperties declarativeConfigProperties;
+  private final SqlQueryMaxLengthParser tested = new SqlQueryMaxLengthParser();
+
+  @BeforeAll
+  static void setup() {
+    try (InputStream resourceAsStream =
+        SqlQueryMaxLengthParserTest.class.getResourceAsStream("/sdk-config.yaml")) {
+      DeclarativeConfigProperties configProperties =
+          DeclarativeConfiguration.toConfigProperties(resourceAsStream);
+      declarativeConfigProperties =
+          configProperties
+              .getStructured("instrumentation/development", DeclarativeConfigProperties.empty())
+              .getStructured("java", DeclarativeConfigProperties.empty())
+              .getStructured("solarwinds");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testConvertValidValue() throws InvalidConfigException {
+    Integer result = tested.convert(declarativeConfigProperties);
+    assertEquals(4096, result);
+  }
+
+  @Test
+  void testConvertNull() throws InvalidConfigException {
+    Integer result = tested.convert(DeclarativeConfigProperties.empty());
+    assertNull(result);
+  }
+
+  @Test
+  void testConvertBelowRange() {
+    assertThrows(InvalidConfigException.class, () -> tested.convert(propsWithValue(100)));
+  }
+
+  @Test
+  void testConvertAboveRange() {
+    assertThrows(InvalidConfigException.class, () -> tested.convert(propsWithValue(200000)));
+  }
+
+  @Test
+  void configKey() {
+    assertEquals("agent.sqlQueryMaxLength", tested.configKey());
+  }
+
+  private DeclarativeConfigProperties propsWithValue(int value) {
+    String yaml = "agent.sqlQueryMaxLength: " + value + "\n";
+    return DeclarativeConfiguration.toConfigProperties(
+        new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/TriggerTraceParserTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/TriggerTraceParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.opentelemetry.extensions.config.parser.yaml;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class TriggerTraceParserTest {
+  private static DeclarativeConfigProperties declarativeConfigProperties;
+  private final TriggerTraceParser tested = new TriggerTraceParser();
+
+  @BeforeAll
+  static void setup() {
+    try (InputStream resourceAsStream =
+        TriggerTraceParserTest.class.getResourceAsStream("/sdk-config.yaml")) {
+      DeclarativeConfigProperties configProperties =
+          DeclarativeConfiguration.toConfigProperties(resourceAsStream);
+      declarativeConfigProperties =
+          configProperties
+              .getStructured("instrumentation/development", DeclarativeConfigProperties.empty())
+              .getStructured("java", DeclarativeConfigProperties.empty())
+              .getStructured("solarwinds");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testConvertTrue() {
+    Boolean result = tested.convert(declarativeConfigProperties);
+    assertTrue(result);
+  }
+
+  @Test
+  void testConvertNull() {
+    Boolean result = tested.convert(DeclarativeConfigProperties.empty());
+    assertTrue(result);
+  }
+
+  @Test
+  void configKey() {
+    assertEquals("agent.triggerTrace", tested.configKey());
+  }
+}

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
@@ -17,10 +17,13 @@
 package com.solarwinds.opentelemetry.extensions.config.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 
+import com.solarwinds.joboe.config.ConfigManager;
 import com.solarwinds.joboe.config.ConfigProperty;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
@@ -34,6 +37,7 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRec
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProviderModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PeriodicMetricReaderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PropagatorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SamplerModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanProcessorPropertyModel;
@@ -50,6 +54,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("all")
 @ExtendWith(MockitoExtension.class)
 class SharedConfigCustomizerProviderTest {
 
@@ -65,6 +70,8 @@ class SharedConfigCustomizerProviderTest {
   void testCustomize() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
+            .withTracerProvider(new TracerProviderModel())
+            .withLoggerProvider(new LoggerProviderModel())
             .withInstrumentationDevelopment(
                 new ExperimentalInstrumentationModel()
                     .withJava(
@@ -131,6 +138,7 @@ class SharedConfigCustomizerProviderTest {
   void testCustomize1() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
+            .withTracerProvider(new TracerProviderModel())
             .withInstrumentationDevelopment(
                 new ExperimentalInstrumentationModel()
                     .withJava(
@@ -194,6 +202,7 @@ class SharedConfigCustomizerProviderTest {
   void testCustomizeSetsExperimentalStacktraceWhenNotSet() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
+            .withTracerProvider(new TracerProviderModel())
             .withInstrumentationDevelopment(
                 new ExperimentalInstrumentationModel()
                     .withJava(
@@ -270,6 +279,7 @@ class SharedConfigCustomizerProviderTest {
   void testCustomize2() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
+            .withLoggerProvider(new LoggerProviderModel())
             .withInstrumentationDevelopment(
                 new ExperimentalInstrumentationModel()
                     .withJava(
@@ -310,6 +320,7 @@ class SharedConfigCustomizerProviderTest {
   void UrlShouldNotChangeWhenNotApm() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
+            .withLoggerProvider(new LoggerProviderModel())
             .withInstrumentationDevelopment(
                 new ExperimentalInstrumentationModel()
                     .withJava(
@@ -350,6 +361,7 @@ class SharedConfigCustomizerProviderTest {
   void UrlShouldNotChangeWhenNotApm2() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
+            .withLoggerProvider(new LoggerProviderModel())
             .withInstrumentationDevelopment(
                 new ExperimentalInstrumentationModel()
                     .withJava(
@@ -384,5 +396,129 @@ class SharedConfigCustomizerProviderTest {
     Map<String, Object> logConfigs = logExporterProperty.getAdditionalProperties();
     assertEquals("http://localhost:4317/v1/logs", logConfigs.get("endpoint"));
     assertEquals("authorization=Bearer token", logConfigs.get("headers_list"));
+  }
+
+  @Test
+  void tracesNotConfiguredWhenTracerProviderAbsent() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withLoggerProvider(new LoggerProviderModel())
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    assertNull(openTelemetryConfigurationModel.getTracerProvider());
+    assertNotNull(openTelemetryConfigurationModel.getLoggerProvider());
+    assertNotNull(openTelemetryConfigurationModel.getMeterProvider());
+    assertNotNull(openTelemetryConfigurationModel.getPropagator());
+  }
+
+  @Test
+  void logsNotConfiguredWhenLoggerProviderAbsent() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withTracerProvider(new TracerProviderModel())
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    assertNull(openTelemetryConfigurationModel.getLoggerProvider());
+    assertNotNull(openTelemetryConfigurationModel.getTracerProvider());
+    assertNotNull(openTelemetryConfigurationModel.getTracerProvider().getSampler());
+    assertNotNull(openTelemetryConfigurationModel.getMeterProvider());
+  }
+
+  @Test
+  void propagatorsAppendedToExistingCompositeList() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withPropagator(new PropagatorModel().withCompositeList("tracecontext,baggage"))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    assertEquals(
+        "tracecontext,baggage," + ContextPropagatorComponentProvider.COMPONENT_NAME,
+        openTelemetryConfigurationModel.getPropagator().getCompositeList());
+  }
+
+  @Test
+  void metricsExportDisabledWhenMeterProviderAbsent() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    assertNotNull(openTelemetryConfigurationModel.getMeterProvider());
+    assertFalse((Boolean) ConfigManager.getConfig(ConfigProperty.AGENT_EXPORT_METRICS_ENABLED));
   }
 }

--- a/libs/shared/src/test/resources/sdk-config.yaml
+++ b/libs/shared/src/test/resources/sdk-config.yaml
@@ -150,30 +150,7 @@ instrumentation/development:
           delimiter: ":"
           attributes:
             - HandlerName
+      agent.triggerTrace: true
+      agent.sqlQueryMaxLength: 4096
       agent.serviceKey: ${SW_APM_SERVICE_KEY}
       agent.collector: apm.collector.na-01.st-ssp.solarwinds.com
-      monitor.jmx.enable: true
-      monitor.jmx.scopes: |
-        {
-          "java.lang:type=MemoryPool,*": [
-            "Usage"
-          ],
-          "java.lang:type=Memory": [
-            "HeapMemoryUsage",
-            "NonHeapMemoryUsage"
-          ],
-          "java.lang:type=GarbageCollector,*": [
-            "CollectionTime"
-          ],
-          "java.lang:type=Threading": [
-            "ThreadCount"
-          ],
-          "java.lang:type=OperatingSystem": [
-            "ProcessCpuTime",
-            "AvailableProcessors",
-            "ProcessCpuLoad"
-          ],
-          "java.lang:type=Runtime,*": [
-            "Uptime"
-          ]
-        }

--- a/sdk-config.yaml
+++ b/sdk-config.yaml
@@ -28,7 +28,7 @@ tracer_provider:
 # Configure meter provider.
 meter_provider:
 
-# Configure logger provider.
+# Configure logger provider. Remove to disable log export
 logger_provider:
 
 instrumentation/development:

--- a/smoke-tests/apm-config.json
+++ b/smoke-tests/apm-config.json
@@ -19,30 +19,6 @@
       "tracing": "disabled"
     }
   ],
-  "monitor.jmx.scopes": {
-    "java.lang:type=MemoryPool,*": [
-      "Usage"
-    ],
-    "java.lang:type=Memory": [
-      "HeapMemoryUsage",
-      "NonHeapMemoryUsage"
-    ],
-    "java.lang:type=GarbageCollector,*": [
-      "CollectionTime"
-    ],
-    "java.lang:type=Threading": [
-      "ThreadCount"
-    ],
-    "java.lang:type=OperatingSystem": [
-      "ProcessCpuTime",
-      "AvailableProcessors",
-      "ProcessCpuLoad"
-    ],
-    "java.lang:type=Runtime,*": [
-      "Uptime"
-    ]
-  },
-  "monitor.jmx.enable": true,
   "profiler": {
     "enabled": true,
     "interval": 10


### PR DESCRIPTION
## Summary

Aligns the declarative configuration customizers with the principle that user-provided YAML config is authoritative. Instead of creating default provider models (TracerProvider, LoggerProvider, Propagator) when absent, the customizers now only configure signals that the user explicitly declared. Also removes the defunct JMX monitoring config properties and their references throughout the codebase.

## Changes

### Respect user-declared signal providers
- `SharedConfigCustomizerProvider` no longer creates `TracerProviderModel` or `LoggerProviderModel` when they are absent from the config. Sampler, span processors, span exporters, and log exporters are only added when their respective provider is declared by the user.
- `CustomConfigCustomizerProvider` similarly guards processor injection behind a null check on `TracerProviderModel`.
- When `MeterProviderModel` is absent, a default is still created (metrics pipeline requires it), but `AGENT_EXPORT_METRICS_ENABLED` is set to `false` so no metric data is exported without explicit opt-in.

### Propagator handling made additive
- If the user already declares a `PropagatorModel` with a `compositeList`, the SolarWinds propagator is appended rather than replacing the list. A new default list is only set when no propagator config exists.

### New YAML config parsers
- `TriggerTraceParser` — reads `agent.triggerTrace` (boolean, defaults to `true`).
- `SqlQueryMaxLengthParser` — reads `agent.sqlQueryMaxLength` (integer, range-validated against existing constants).

### Remove defunct JMX monitoring config
- Removed `MONITOR_*` config properties (`JMX_SCOPES`, `JMX_ENABLE`, `JMX_MAX_ENTRY`, `METRICS_FLUSH_INTERVAL`, `SPAN_METRICS_ENABLE`) and the `MONITOR` config group.
- Cleaned up all references in lambda config, smoke-test config, and test YAML fixtures.
- Added YAML key for `AGENT_LOG_FILE` (`agent.javaLogFile`).
- `UrlSampleRateConfigParser` no longer skips null `TraceConfig` entries — the null guard was unnecessary.

### Test coverage
- Added tests for absent-provider scenarios (`tracesNotConfiguredWhenTracerProviderAbsent`, `logsNotConfiguredWhenLoggerProviderAbsent`, `metricsExportDisabledWhenMeterProviderAbsent`, `propagatorsAppendedToExistingCompositeList`, `processorsNotAddedWhenTracerProviderAbsent`).
- Added unit tests for both new parsers.
- Updated existing tests to explicitly provide the provider models they depend on.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
