### PR TITLE
Fix - address declarative config warning

### DIFF
--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/DeclarativeConfigParser.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/parser/yaml/DeclarativeConfigParser.java
@@ -54,24 +54,25 @@ public final class DeclarativeConfigParser {
         unknownKeys.add(key);
       } else {
         Object parsed = null;
-        Class<?> typeClass = configProperty.getTypeClass();
 
-        if (typeClass == String.class) {
-          parsed = declarativeConfigProperties.getString(key);
-
-        } else if (typeClass == Boolean.class) {
-          parsed = declarativeConfigProperties.getBoolean(key);
-
-        } else if (typeClass == Integer.class) {
-          parsed = declarativeConfigProperties.getInt(key);
-
-        } else if (typeClass == Long.class) {
-          parsed = declarativeConfigProperties.getLong(key);
-        }
-
-        if (register.containsKey(key)) {
-          ConfigParser<DeclarativeConfigProperties, Object> configParser = register.get(key);
+        ConfigParser<DeclarativeConfigProperties, Object> configParser = register.get(key);
+        if (configParser != null) {
           parsed = configParser.convert(declarativeConfigProperties);
+        } else {
+          Class<?> typeClass = configProperty.getTypeClass();
+
+          if (typeClass == String.class) {
+            parsed = declarativeConfigProperties.getString(key);
+
+          } else if (typeClass == Boolean.class) {
+            parsed = declarativeConfigProperties.getBoolean(key);
+
+          } else if (typeClass == Integer.class) {
+            parsed = declarativeConfigProperties.getInt(key);
+
+          } else if (typeClass == Long.class) {
+            parsed = declarativeConfigProperties.getLong(key);
+          }
         }
 
         if (parsed != null) {


### PR DESCRIPTION
## TLDR

Reorders config parsing so registered `ConfigParser` implementations are checked before the type-based fallback, eliminating a dead intermediate assignment that produced an unused-result warning.

## Technical Details

`DeclarativeConfigParser.parse()` iterates over YAML config keys and resolves each to a value. Two parsing strategies exist:

1. **Registered parsers** — `ConfigParser` implementations loaded via `ServiceLoader`, keyed by config name (e.g., `agent.logging` uses a structured parser).
2. **Type-based fallback** — dispatches on `ConfigProperty.getTypeClass()` to call `getString`, `getBoolean`, `getInt`, or `getLong`.

Previously, the type-based parse ran unconditionally for every key, and then a separate `containsKey`/`get` check on the parser registry would overwrite the result. This meant the type-based conversion could trigger a warning for some keys when there's a type-mismatch. This change avoids it by using the config parser first which handles structured types.

The fix restructures the logic into a single `if/else`: look up the registered parser first via `register.get(key)` with a null-check, and only fall back to type-based parsing when no registered parser exists. This also collapses the prior double map lookup (`containsKey` + `get`) into a single `get`.

Behavior is unchanged — registered parsers always took precedence, and they still do. The difference is that the type-based branch no longer executes when it would be immediately overwritten.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
