### PR TITLE
Fix - release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,9 +288,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Build agent
-        run: ./gradlew clean build -x test
-
       - name: Checkout solarwinds-actions/gha-signing
         uses: actions/checkout@v6
         with:
@@ -306,15 +303,15 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Build and Set agent version
+        id: set_version
+        uses: ./.github/actions/version
+
       - name: Sign Files
         uses: ./.github/actions/gha-signing/ats-sign
         with:
           files-to-sign: '*.jar'
           cert-profile: ${{ vars.ATS_CERT_PROFILE }}
-
-      - name: Set agent version
-        id: set_version
-        uses: ./.github/actions/version
 
       - name: Upload signed artifact
         run: |


### PR DESCRIPTION
## TLDR

Fixes the release signing job so that signed JARs are not overwritten before upload.

## Details

The `sign_release` job had the "Set agent version" step running *after* the signing step. That version action calls `./gradlew build -x test` to extract the version from the built JAR's manifest, which rebuilds the agent and overwrites the signed JARs with unsigned ones. The uploaded artifacts were therefore never actually signed.

The fix removes the redundant standalone build step and moves the version action to run before signing. This ensures the signing step is the last operation to touch the JARs before upload.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
