### PR TITLE
Internal - add stale.yml and minor refactor

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Close Stale PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+        with:
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had
+            any activity in the last 7 days. It will be closed in 7 days if no
+            further activity occurs.
+          close-pr-message: >
+            This PR has been automatically closed because it remained stale for
+            7 days with no further activity. Feel free to reopen it if you plan
+            to continue working on it.
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcClient.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcClient.java
@@ -366,13 +366,7 @@ public class RpcClient implements com.solarwinds.joboe.core.rpc.Client {
     }
   }
 
-  @Override
-  protected void finalize() throws Throwable {
-    close();
-    super.finalize();
-  }
-
-  private final void asyncInitClient() {
+  private void asyncInitClient() {
     ExecutorService executorService =
         Executors.newSingleThreadExecutor(DaemonThreadFactory.newInstance("init-rpc-client"));
     executorService.submit(() -> initClient());


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automatically manage stale PRs and removes a deprecated `finalize()` override from `RpcClient`.

## Details

### Stale PR Workflow

Introduces a new `stale.yml` GitHub Actions workflow that runs daily (and on-demand via `workflow_dispatch`). It uses `actions/stale` pinned to a specific commit SHA to:

- Mark PRs as stale after 7 days of inactivity
- Auto-close stale PRs after an additional 7 days with no activity
- Label stale PRs with `stale` for visibility

This keeps the PR list clean and ensures abandoned work doesn't accumulate indefinitely.

### RpcClient Cleanup

- Removes the `finalize()` override that called `close()`. Object finalization is deprecated since Java 9, has unpredictable timing, and can cause resurrection issues or delays in resource cleanup. Callers should rely on explicit `close()` calls instead.
- Removes the redundant `final` modifier from the `asyncInitClient()` private method — private methods are implicitly non-overridable.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
