### PR TITLE
Fix - log record customization and update config file version

### DIFF
--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
@@ -256,7 +256,10 @@ public class SharedConfigCustomizerProvider implements DeclarativeConfigurationC
 
     boolean hasExporter =
         processors.stream()
-            .anyMatch(logRecordProcessorModel -> logRecordProcessorModel.getBatch() != null);
+            .anyMatch(
+                logRecordProcessorModel ->
+                    logRecordProcessorModel.getBatch() != null
+                        || logRecordProcessorModel.getSimple() != null);
 
     if (hasExporter) {
       return;

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
@@ -28,6 +28,7 @@ import com.solarwinds.joboe.config.ConfigProperty;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalInstrumentationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationPropertyModel;
@@ -35,10 +36,16 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRec
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProviderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MeterProviderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricReaderModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PeriodicMetricReaderModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PropagatorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SamplerModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleLogRecordProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleSpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanProcessorPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TracerProviderModel;
@@ -199,6 +206,129 @@ class SharedConfigCustomizerProviderTest {
   }
 
   @Test
+  void customizeShouldNotSetMetricReaderWhenOneIsSpecified() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withMeterProvider(
+                new MeterProviderModel()
+                    .withReaders(Collections.singletonList(new MetricReaderModel())))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    MeterProviderModel meterProvider = openTelemetryConfigurationModel.getMeterProvider();
+    MetricReaderModel metricReaderModel = meterProvider.getReaders().get(0);
+    assertNull(metricReaderModel.getPeriodic());
+  }
+
+  @Test
+  void customizeShouldNotSetTraceExporterWhenBatchIsSpecified() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withTracerProvider(
+                new TracerProviderModel()
+                    .withProcessors(
+                        Collections.singletonList(
+                            new SpanProcessorModel()
+                                .withBatch(
+                                    new BatchSpanProcessorModel()
+                                        .withExporter(new SpanExporterModel())))))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    TracerProviderModel tracerProvider = openTelemetryConfigurationModel.getTracerProvider();
+    SpanProcessorModel spanProcessorModel = tracerProvider.getProcessors().get(0);
+    BatchSpanProcessorModel batch = spanProcessorModel.getBatch();
+
+    assertNotNull(batch);
+    SpanExporterModel exporter = batch.getExporter();
+    SpanExporterPropertyModel spanExporterPropertyModel =
+        exporter.getAdditionalProperties().get(SpanExporterComponentProvider.COMPONENT_NAME);
+
+    assertNull(spanExporterPropertyModel);
+  }
+
+  @Test
+  void customizeShouldNotSetTraceExporterWhenSimpleIsSpecified() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withTracerProvider(
+                new TracerProviderModel()
+                    .withProcessors(
+                        Collections.singletonList(
+                            new SpanProcessorModel()
+                                .withSimple(
+                                    new SimpleSpanProcessorModel()
+                                        .withExporter(new SpanExporterModel())))))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    TracerProviderModel tracerProvider = openTelemetryConfigurationModel.getTracerProvider();
+    SpanProcessorModel spanProcessorModel = tracerProvider.getProcessors().get(0);
+    SimpleSpanProcessorModel simple = spanProcessorModel.getSimple();
+
+    assertNotNull(simple);
+    SpanExporterModel exporter = simple.getExporter();
+    SpanExporterPropertyModel spanExporterPropertyModel =
+        exporter.getAdditionalProperties().get(SpanExporterComponentProvider.COMPONENT_NAME);
+
+    assertNull(spanExporterPropertyModel);
+  }
+
+  @Test
   void testCustomizeSetsExperimentalStacktraceWhenNotSet() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()
@@ -314,6 +444,96 @@ class SharedConfigCustomizerProviderTest {
     Map<String, Object> logConfigs = logExporterProperty.getAdditionalProperties();
     assertEquals("https://otel.collector.com/v1/logs", logConfigs.get("endpoint"));
     assertEquals("authorization=Bearer token", logConfigs.get("headers_list"));
+  }
+
+  @Test
+  void customizeShouldNotSetLogExporterWhenBatchIsSpecified() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withLoggerProvider(
+                new LoggerProviderModel()
+                    .withProcessors(
+                        Collections.singletonList(
+                            new LogRecordProcessorModel()
+                                .withBatch(
+                                    new BatchLogRecordProcessorModel()
+                                        .withExporter(new LogRecordExporterModel())))))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "http://apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    LoggerProviderModel loggerProvider = openTelemetryConfigurationModel.getLoggerProvider();
+    LogRecordProcessorModel logRecordProcessorModel = loggerProvider.getProcessors().get(0);
+    BatchLogRecordProcessorModel batch = logRecordProcessorModel.getBatch();
+
+    assertNotNull(batch);
+    LogRecordExporterModel exporter = batch.getExporter();
+    LogRecordExporterPropertyModel logExporterProperty =
+        exporter.getAdditionalProperties().get(LogExporterComponentProvider.COMPONENT_NAME);
+
+    assertNull(logExporterProperty);
+  }
+
+  @Test
+  void customizeShouldNotSetLogExporterWhenSimpleIsSpecified() {
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withLoggerProvider(
+                new LoggerProviderModel()
+                    .withProcessors(
+                        Collections.singletonList(
+                            new LogRecordProcessorModel()
+                                .withSimple(
+                                    new SimpleLogRecordProcessorModel()
+                                        .withExporter(new LogRecordExporterModel())))))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "http://apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    LoggerProviderModel loggerProvider = openTelemetryConfigurationModel.getLoggerProvider();
+    LogRecordProcessorModel logRecordProcessorModel = loggerProvider.getProcessors().get(0);
+    SimpleLogRecordProcessorModel simple = logRecordProcessorModel.getSimple();
+
+    assertNotNull(simple);
+    LogRecordExporterModel exporter = simple.getExporter();
+    LogRecordExporterPropertyModel logExporterProperty =
+        exporter.getAdditionalProperties().get(LogExporterComponentProvider.COMPONENT_NAME);
+
+    assertNull(logExporterProperty);
   }
 
   @Test

--- a/sdk-config.yaml
+++ b/sdk-config.yaml
@@ -6,7 +6,7 @@
 # vars defined in https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
 
 # The file format version.
-file_format: "0.4"
+file_format: "1.0"
 
 # Configure if the SDK is disabled or not. This setting is optional, the default value when not provided is for the SDK to be enabled
 disabled: false


### PR DESCRIPTION
# Fix log record customization and update config file version

## TLDR

Fixed a bug where user-specified simple log record processors were silently overwritten by the default batch exporter. Also bumped the declarative config file format version to `1.0` and added tests covering exporter override behavior for all signal types.

## Details

### Bug fix: simple log record processor detection

The `addLogExporter` method checks whether the user has already configured a log record processor before injecting the default batch exporter. Previously, it only checked for `batch` processors:

```java
logRecordProcessorModel.getBatch() != null
```

This meant users who configured a `simple` processor had their setup silently replaced. The analogous trace exporter method already handled both processor types. This change adds the missing `getSimple() != null` check to bring log handling into parity with trace handling.

### Config file version bump

Updated `file_format` from `"0.4"` to `"1.0"` to align with the current OTel declarative configuration schema version.

### New tests

Added tests verifying that user-specified exporters are not overwritten for:

- **Traces** — batch and simple span processors
- **Logs** — batch and simple log record processors
- **Metrics** — user-provided metric reader


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
