### PR TITLE
New - bump upstream version and add use of complex attribute api in test

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:8.2.1")
   implementation("io.freefair.gradle:lombok-plugin:8.13")
 
-  implementation("io.opentelemetry.instrumentation:gradle-plugins:2.25.0-alpha")
+  implementation("io.opentelemetry.instrumentation:gradle-plugins:2.27.0-alpha")
   implementation("com.gradleup.shadow:shadow-gradle-plugin:9.4.1")
   implementation("com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:6.0.7")
   implementation("com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.4.8")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
   `java-platform`
 }
 
-val otelAgentVersion = "2.26.1"
-val otelSdkVersion = "1.60.1"
+val otelAgentVersion = "2.27.0"
+val otelSdkVersion = "1.61.0"
 
 val mockitoVersion = "5.2.0"
 val byteBuddyVersion = "1.18.8"

--- a/smoke-tests/spring-boot-webmvc/build.gradle
+++ b/smoke-tests/spring-boot-webmvc/build.gradle
@@ -38,7 +38,7 @@ repositories {
     }
 }
 
-def sdkVersion = System.getenv("AGENT_VERSION") ?: "2.6.0"
+def sdkVersion = System.getenv("AGENT_VERSION") ?: "3.1.3"
 dependencies {
     implementation("com.solarwinds:solarwinds-otel-sdk:$sdkVersion-SNAPSHOT")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
@@ -48,8 +48,8 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.5.0")
-    runtimeOnly("io.opentelemetry:opentelemetry-api:1.39.0")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.27.0")
+    runtimeOnly("io.opentelemetry:opentelemetry-api:1.61.0")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/smoke-tests/spring-boot-webmvc/src/main/kotlin/com/solarwinds/webmvc/Controller.kt
+++ b/smoke-tests/spring-boot-webmvc/src/main/kotlin/com/solarwinds/webmvc/Controller.kt
@@ -20,6 +20,8 @@ package com.solarwinds.webmvc
 import com.solarwinds.api.ext.SolarwindsAgent
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey.valueKey
+import io.opentelemetry.api.common.Value
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import mu.KotlinLogging
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,6 +32,7 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.ByteBuffer
 
 @RestController
 @RequestMapping
@@ -42,7 +45,33 @@ class Controller {
     fun greet(@PathVariable name: String): String{
         val startSpan = tracer.spanBuilder("greet-span")
             .setAttribute("sw.test.source", "SDK.trace.test")
+            .setAttribute(valueKey("complex.list"), Value.of(listOf<Value<String>>(Value.of("one"), Value.of("two"))))
+            .setAttribute(
+                valueKey("complex.map"),
+                Value.of(mapOf<String, Value<String>>("one" to Value.of("one"), "two" to Value.of("two")))
+            )
+            .setAttribute(
+                valueKey("complex.bytearray"),
+                Value.of(byteArrayOf(1, 2, 3, 4, 5)),
+            )
+            .setAttribute(
+                valueKey("complex.map.bytearray"), Value.of(
+                    mapOf<String, Value<ByteBuffer>>(
+                        "one" to Value.of(
+                            ByteArray(10) { (it * 3).toByte() }), "two" to Value.of(ByteArray(20) { (it * 2).toByte() })
+                    )
+                )
+            )
+            .setAttribute(
+                valueKey("complex.map.bytearray.big"), Value.of(
+                    mapOf<String, Value<ByteBuffer>>(
+                        "one" to Value.of(
+                            ByteArray(128) { (it * 3).toByte() }), "two" to Value.of(ByteArray(256) { (it * 2).toByte() })
+                    )
+                )
+            )
             .startSpan()
+
         startSpan.makeCurrent().use {
         SolarwindsAgent.setTransactionName(name)
             startSpan.end()


### PR DESCRIPTION
## Summary

Bumps upstream OpenTelemetry dependencies to the latest release and adds complex attribute API usage to the smoke test to validate support for `Value`-based attribute types.

## Details

### Version bumps

- OTel Java Agent: `2.26.1` → `2.27.0`
- OTel SDK: `1.60.1` → `1.61.0`
- OTel instrumentation Gradle plugin: `2.25.0-alpha` → `2.27.0-alpha`
- Smoke test default SDK version: `2.6.0` → `3.1.3`
- Smoke test OTel annotations: `2.5.0` → `2.27.0`
- Smoke test OTel API: `1.39.0` → `1.61.0`

### Complex attribute test coverage

The smoke test controller now exercises `AttributeKey.valueKey` / `Value.of` APIs to set non-primitive span attributes: lists, maps, byte arrays, and nested maps of byte arrays. This verifies our agent correctly propagates complex attribute types through the telemetry pipeline.

### Validation

The backend handles complex attributes correctly as expected, and so does the UI. However, really large attributes are not visible on the UI hinting at backend validation that drops values beyond a limit.

[Sample trace](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/traces/5CF6B60BEFB543F6E58A70680C1496A0/565693AC0E491BCF/details/breakdown/1F0EC9B78E0C6DC0/attributes?duration=1800&perspective=requests&requestId=565693AC0E491BCF&serviceId=e-1712643928659124224&spanTime=1777046207588&transactionName=aW50LXRlc3Q%3D&sort_by_spans=relativeStartTime&sort_order_spans=ascending&selectedSpanOpen=false)


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
