### PR TITLE
New - Allow user-provided sampler and add out of the box CEL sampler support

### DIFF
--- a/agent-lambda/build.gradle.kts
+++ b/agent-lambda/build.gradle.kts
@@ -82,7 +82,11 @@ tasks {
     filesMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+
     exclude("**/module-info.class")
+    filesMatching(listOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/NOTICE", "META-INF/NOTICE.txt")) {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 
     // exclude known bootstrap dependencies - they can't appear in the inst/ directory
     dependencies {

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -85,6 +85,11 @@ tasks {
     filesMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+
+    filesMatching(listOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/NOTICE", "META-INF/NOTICE.txt")) {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+
     exclude("**/module-info.class")
 
     // exclude known bootstrap dependencies - they can't appear in the inst/ directory

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java
@@ -17,7 +17,6 @@
 package com.solarwinds.opentelemetry.extensions;
 
 import static com.solarwinds.opentelemetry.extensions.config.provider.AutoConfigurationCustomizerProviderImpl.isAgentEnabled;
-import static com.solarwinds.opentelemetry.extensions.config.provider.AutoConfigurationCustomizerProviderImpl.setAgentEnabled;
 
 import com.google.auto.service.AutoService;
 import com.solarwinds.joboe.config.ConfigManager;
@@ -39,7 +38,6 @@ import com.solarwinds.opentelemetry.extensions.config.HttpSettingsReader;
 import com.solarwinds.opentelemetry.extensions.config.HttpSettingsReaderDelegate;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -56,7 +54,7 @@ public class SolarwindsAgentListener implements AgentListener {
 
   @Override
   public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
-    if (isAgentEnabled() && isUsingSolarwindsSampler(autoConfiguredOpenTelemetrySdk)) {
+    if (isAgentEnabled()) {
       executeStartupTasks();
       registerShutdownTasks();
       logger.info(
@@ -64,19 +62,6 @@ public class SolarwindsAgentListener implements AgentListener {
     } else {
       autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk().shutdown();
     }
-  }
-
-  boolean isUsingSolarwindsSampler(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
-    Sampler sampler =
-        autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk().getSdkTracerProvider().getSampler();
-    boolean verdict = sampler instanceof SolarwindsSampler;
-    setAgentEnabled(verdict);
-
-    if (!verdict) {
-      logger.warn(
-          "Not using Solarwinds sampler. Configured sampler is: " + sampler.getDescription());
-    }
-    return verdict;
   }
 
   private void executeStartupTasks() {

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/AutoConfigurationCustomizerProviderImpl.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/AutoConfigurationCustomizerProviderImpl.java
@@ -48,11 +48,6 @@ public class AutoConfigurationCustomizerProviderImpl
     return agentEnabled;
   }
 
-  public static void setAgentEnabled(boolean agentEnabled) {
-    AutoConfigurationCustomizerProviderImpl.agentEnabled =
-        AutoConfigurationCustomizerProviderImpl.agentEnabled && agentEnabled;
-  }
-
   @Override
   public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
     try {

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/AutoConfigurationCustomizerProviderImpl.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/AutoConfigurationCustomizerProviderImpl.java
@@ -78,12 +78,4 @@ public class AutoConfigurationCustomizerProviderImpl
         .addLogRecordExporterCustomizer(new LogRecordExporterCustomizer())
         .addResourceCustomizer(new ResourceCustomizer());
   }
-
-  @Override
-  public int order() {
-    // Here, we return Integer.MAX_VALUE to force our extension customization to execute last.
-    // See https://github.com/appoptics/solarwinds-apm-java/pull/93#discussion_r1165987329 for more
-    // context
-    return Integer.MAX_VALUE;
-  }
 }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListenerTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListenerTest.java
@@ -16,19 +16,19 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.solarwinds.opentelemetry.extensions.config.provider.AutoConfigurationCustomizerProviderImpl;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,35 +39,36 @@ class SolarwindsAgentListenerTest {
 
   @Mock private OpenTelemetrySdk openTelemetrySdkMock;
 
-  @Mock private SdkTracerProvider sdkTracerProviderMock;
-
-  @Mock private Sampler samplerMock;
-
-  @Test
-  void returnFalseWhenOurSamplerIsNotAttached() {
-    when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk())
-        .thenReturn(OpenTelemetrySdk.builder().build());
-
-    assertFalse(tested.isUsingSolarwindsSampler(autoConfiguredOpenTelemetrySdkMock));
-  }
-
-  @Test
-  void returnTrueWhenOurSamplerIsAttached() {
-    when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk()).thenReturn(openTelemetrySdkMock);
-
-    when(openTelemetrySdkMock.getSdkTracerProvider()).thenReturn(sdkTracerProviderMock);
-    when(sdkTracerProviderMock.getSampler()).thenReturn(new SolarwindsSampler());
-
-    assertTrue(tested.isUsingSolarwindsSampler(autoConfiguredOpenTelemetrySdkMock));
-  }
-
   @Test
   void verifySDKIsShutdownWhenBranchIsNotTaken() {
-    when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk()).thenReturn(openTelemetrySdkMock);
-    when(openTelemetrySdkMock.getSdkTracerProvider()).thenReturn(sdkTracerProviderMock);
-    when(sdkTracerProviderMock.getSampler()).thenReturn(samplerMock);
+    try (MockedStatic<AutoConfigurationCustomizerProviderImpl>
+        autoConfigurationCustomizerProviderMockedStatic =
+            mockStatic(AutoConfigurationCustomizerProviderImpl.class)) {
 
-    tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
-    verify(openTelemetrySdkMock).shutdown();
+      autoConfigurationCustomizerProviderMockedStatic
+          .when(AutoConfigurationCustomizerProviderImpl::isAgentEnabled)
+          .thenReturn(false);
+
+      when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk())
+          .thenReturn(openTelemetrySdkMock);
+
+      tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
+      verify(openTelemetrySdkMock).shutdown();
+    }
+  }
+
+  @Test
+  void verifySDKIsNotShutdownWhenBranchIsTaken() {
+    try (MockedStatic<AutoConfigurationCustomizerProviderImpl>
+        autoConfigurationCustomizerProviderMockedStatic =
+            mockStatic(AutoConfigurationCustomizerProviderImpl.class)) {
+
+      autoConfigurationCustomizerProviderMockedStatic
+          .when(AutoConfigurationCustomizerProviderImpl::isAgentEnabled)
+          .thenReturn(true);
+
+      tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
+      verify(openTelemetrySdkMock, never()).shutdown();
+    }
   }
 }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/provider/AutoConfigurationCustomizerProviderImplTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/provider/AutoConfigurationCustomizerProviderImplTest.java
@@ -17,7 +17,6 @@
 package com.solarwinds.opentelemetry.extensions.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.verify;
@@ -58,13 +57,6 @@ class AutoConfigurationCustomizerProviderImplTest {
   void teardown() throws Throwable {
     // Reset the static agentEnabled field to true so it doesn't affect other tests
     AGENT_ENABLED_SETTER.invokeExact(true);
-  }
-
-  @Test
-  void verifyThatWhenDisabledItIsNeverEnabled() {
-    AutoConfigurationCustomizerProviderImpl.setAgentEnabled(false);
-    AutoConfigurationCustomizerProviderImpl.setAgentEnabled(true);
-    assertFalse(AutoConfigurationCustomizerProviderImpl.isAgentEnabled());
   }
 
   @Test

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/provider/AutoConfigurationCustomizerProviderImplTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/provider/AutoConfigurationCustomizerProviderImplTest.java
@@ -16,7 +16,6 @@
 
 package com.solarwinds.opentelemetry.extensions.provider;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.verify;
@@ -57,11 +56,6 @@ class AutoConfigurationCustomizerProviderImplTest {
   void teardown() throws Throwable {
     // Reset the static agentEnabled field to true so it doesn't affect other tests
     AGENT_ENABLED_SETTER.invokeExact(true);
-  }
-
-  @Test
-  void verifyThatOrderReturnsIntMax() {
-    assertEquals(Integer.MAX_VALUE, tested.order());
   }
 
   @Test

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     api("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
     api("io.opentelemetry.contrib:opentelemetry-span-stacktrace:$otelJavaContribVersion")
+    api("io.opentelemetry.contrib:opentelemetry-cel-sampler:$otelJavaContribVersion")
     api("io.opentelemetry.semconv:opentelemetry-semconv-incubating:$opentelemetrySemconvAlpha")
 
     api("io.opentelemetry:opentelemetry-api-incubator:$opentelemetryAlpha")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     api("io.opentelemetry:opentelemetry-sdk-extension-incubator:$opentelemetryAlpha")
 
     api("org.junit.jupiter:junit-jupiter-params:$junit5")
+    api("dev.cel:cel:0.13.0")
 
   }
 }

--- a/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/DefaultAutoConfigurationCustomizerProvider.java
+++ b/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/DefaultAutoConfigurationCustomizerProvider.java
@@ -18,7 +18,6 @@ package com.solarwinds.opentelemetry.extensions;
 
 import com.google.auto.service.AutoService;
 import com.solarwinds.joboe.config.InvalidConfigException;
-import com.solarwinds.joboe.config.JavaRuntimeVersionChecker;
 import com.solarwinds.joboe.logging.Logger;
 import com.solarwinds.joboe.logging.LoggerFactory;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
@@ -29,19 +28,11 @@ public class DefaultAutoConfigurationCustomizerProvider
     implements AutoConfigurationCustomizerProvider {
   private static final Logger logger = LoggerFactory.getLogger();
 
-  private static boolean agentEnabled;
+  private static boolean agentEnabled = true;
 
   static {
     try {
-      agentEnabled = JavaRuntimeVersionChecker.isJdkVersionSupported();
-      if (agentEnabled) {
-        LambdaConfigurationLoader.load();
-      } else {
-        logger.warn(
-            String.format(
-                "Unsupported Java runtime version: %s. The lowest Java version supported is %s.",
-                System.getProperty("java.version"), JavaRuntimeVersionChecker.minVersionSupported));
-      }
+      LambdaConfigurationLoader.load();
 
     } catch (InvalidConfigException invalidConfigException) {
       logger.warn("Error loading agent config", invalidConfigException);
@@ -55,11 +46,6 @@ public class DefaultAutoConfigurationCustomizerProvider
 
   public static boolean isAgentEnabled() {
     return agentEnabled;
-  }
-
-  public static void setAgentEnabled(boolean agentEnabled) {
-    DefaultAutoConfigurationCustomizerProvider.agentEnabled =
-        DefaultAutoConfigurationCustomizerProvider.agentEnabled && agentEnabled;
   }
 
   @Override

--- a/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/DefaultAutoConfigurationCustomizerProvider.java
+++ b/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/DefaultAutoConfigurationCustomizerProvider.java
@@ -56,12 +56,4 @@ public class DefaultAutoConfigurationCustomizerProvider
         .addResourceCustomizer(new ResourceCustomizer())
         .addMetricExporterCustomizer(new MetricExporterCustomizer());
   }
-
-  @Override
-  public int order() {
-    // Here, we return Integer.MAX_VALUE to force our extension customization to execute last.
-    // See https://github.com/appoptics/solarwinds-apm-java/pull/93#discussion_r1165987329 for more
-    // context
-    return Integer.MAX_VALUE;
-  }
 }

--- a/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/LambdaAgentListener.java
+++ b/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/LambdaAgentListener.java
@@ -17,7 +17,6 @@
 package com.solarwinds.opentelemetry.extensions;
 
 import static com.solarwinds.opentelemetry.extensions.DefaultAutoConfigurationCustomizerProvider.isAgentEnabled;
-import static com.solarwinds.opentelemetry.extensions.DefaultAutoConfigurationCustomizerProvider.setAgentEnabled;
 
 import com.google.auto.service.AutoService;
 import com.solarwinds.joboe.logging.Logger;
@@ -25,7 +24,6 @@ import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.SettingsManager;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 /**
  * Executes startup task after it's safe to do so. See <a
@@ -37,7 +35,7 @@ public class LambdaAgentListener implements AgentListener {
 
   @Override
   public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
-    if (isAgentEnabled() && isUsingSolarwindsSampler(autoConfiguredOpenTelemetrySdk)) {
+    if (isAgentEnabled()) {
       SettingsManager.initialize(
           new AwsLambdaSettingsFetcher(new FileSettingsReader("/tmp/solarwinds-apm-settings.json")),
           SamplingConfigProvider.getSamplingConfiguration());
@@ -46,18 +44,5 @@ public class LambdaAgentListener implements AgentListener {
       autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk().shutdown();
       logger.info("SolarwindsAPM OpenTelemetry extensions is disabled");
     }
-  }
-
-  boolean isUsingSolarwindsSampler(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
-    Sampler sampler =
-        autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk().getSdkTracerProvider().getSampler();
-    boolean verdict = sampler instanceof SolarwindsSampler;
-    setAgentEnabled(verdict);
-
-    if (!verdict) {
-      logger.warn(
-          "Not using Solarwinds sampler. Configured sampler is: " + sampler.getDescription());
-    }
-    return verdict;
   }
 }

--- a/libs/lambda/src/test/java/com/solarwinds/opentelemetry/extensions/DefaultAutoConfigurationCustomizerProviderTest.java
+++ b/libs/lambda/src/test/java/com/solarwinds/opentelemetry/extensions/DefaultAutoConfigurationCustomizerProviderTest.java
@@ -16,7 +16,6 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,10 +52,5 @@ class DefaultAutoConfigurationCustomizerProviderTest {
     verify(autoConfigurationCustomizerMock).addResourceCustomizer(any());
 
     verify(autoConfigurationCustomizerMock).addMetricExporterCustomizer(any());
-  }
-
-  @Test
-  void returnIntMax() {
-    assertEquals(Integer.MAX_VALUE, tested.order());
   }
 }

--- a/libs/lambda/src/test/java/com/solarwinds/opentelemetry/extensions/LambdaAgentListenerTest.java
+++ b/libs/lambda/src/test/java/com/solarwinds/opentelemetry/extensions/LambdaAgentListenerTest.java
@@ -25,8 +25,6 @@ import static org.mockito.Mockito.when;
 import com.solarwinds.joboe.sampling.SettingsManager;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -42,10 +40,6 @@ class LambdaAgentListenerTest {
 
   @Mock private OpenTelemetrySdk openTelemetrySdkMock;
 
-  @Mock private SdkTracerProvider sdkTracerProviderMock;
-
-  @Mock private Sampler samplerMock;
-
   @Test
   void verifySettingsManagerIsInitializedWhenConditionsAreMet() {
     try (MockedStatic<SettingsManager> settingsManagerMock = mockStatic(SettingsManager.class);
@@ -56,11 +50,6 @@ class LambdaAgentListenerTest {
       defaultAutoConfigurationCustomizerProviderMock
           .when(DefaultAutoConfigurationCustomizerProvider::isAgentEnabled)
           .thenReturn(true);
-      when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk())
-          .thenReturn(openTelemetrySdkMock);
-      when(openTelemetrySdkMock.getSdkTracerProvider()).thenReturn(sdkTracerProviderMock);
-
-      when(sdkTracerProviderMock.getSampler()).thenReturn(new SolarwindsSampler());
 
       tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
       settingsManagerMock.verify(() -> SettingsManager.initialize(any(), any()));
@@ -76,12 +65,10 @@ class LambdaAgentListenerTest {
 
       defaultAutoConfigurationCustomizerProviderMock
           .when(DefaultAutoConfigurationCustomizerProvider::isAgentEnabled)
-          .thenReturn(true);
+          .thenReturn(false);
+
       when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk())
           .thenReturn(openTelemetrySdkMock);
-      when(openTelemetrySdkMock.getSdkTracerProvider()).thenReturn(sdkTracerProviderMock);
-
-      when(sdkTracerProviderMock.getSampler()).thenReturn(samplerMock);
 
       tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
       settingsManagerMock.verify(() -> SettingsManager.initialize(any(), any()), never());
@@ -90,11 +77,19 @@ class LambdaAgentListenerTest {
 
   @Test
   void verifySDKIsShutdownWhenBranchIsNotTaken() {
-    when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk()).thenReturn(openTelemetrySdkMock);
-    when(openTelemetrySdkMock.getSdkTracerProvider()).thenReturn(sdkTracerProviderMock);
-    when(sdkTracerProviderMock.getSampler()).thenReturn(samplerMock);
+    try (MockedStatic<DefaultAutoConfigurationCustomizerProvider>
+        defaultAutoConfigurationCustomizerProviderMock =
+            mockStatic(DefaultAutoConfigurationCustomizerProvider.class)) {
 
-    tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
-    verify(openTelemetrySdkMock).shutdown();
+      defaultAutoConfigurationCustomizerProviderMock
+          .when(DefaultAutoConfigurationCustomizerProvider::isAgentEnabled)
+          .thenReturn(false);
+
+      when(autoConfiguredOpenTelemetrySdkMock.getOpenTelemetrySdk())
+          .thenReturn(openTelemetrySdkMock);
+
+      tested.afterAgent(autoConfiguredOpenTelemetrySdkMock);
+      verify(openTelemetrySdkMock).shutdown();
+    }
   }
 }

--- a/libs/shared/build.gradle.kts
+++ b/libs/shared/build.gradle.kts
@@ -42,6 +42,11 @@ dependencies {
     exclude(module = "opentelemetry-sdk", group = "io.opentelemetry") // the agent includes this
   }
 
+  implementation("io.opentelemetry.contrib:opentelemetry-cel-sampler") {
+    exclude(module = "opentelemetry-sdk", group = "io.opentelemetry") // the agent includes this
+    exclude(group = "com.google.code.findbugs", module = "annotations")
+  }
+
   implementation("org.json:json")
   implementation("com.google.code.gson:gson")
   implementation("com.github.ben-manes.caffeine:caffeine")

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProvider.java
@@ -152,10 +152,13 @@ public class SharedConfigCustomizerProvider implements DeclarativeConfigurationC
   }
 
   private void addSampler(TracerProviderModel model) {
-    model.withSampler(
-        new SamplerModel()
-            .withAdditionalProperty(
-                SamplerComponentProvider.COMPONENT_NAME, new SamplerPropertyModel()));
+    SamplerModel sampler = model.getSampler();
+    if (sampler == null) {
+      model.withSampler(
+          new SamplerModel()
+              .withAdditionalProperty(
+                  SamplerComponentProvider.COMPONENT_NAME, new SamplerPropertyModel()));
+    }
   }
 
   private void addContextPropagators(PropagatorModel model) {

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/config/provider/SharedConfigCustomizerProviderTest.java
@@ -651,6 +651,41 @@ class SharedConfigCustomizerProviderTest {
   }
 
   @Test
+  void customizeShouldNotOverrideSamplerWhenOneIsAlreadyConfigured() {
+    SamplerModel userSampler = new SamplerModel().withAdditionalProperty("cel", null);
+
+    OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
+        new OpenTelemetryConfigurationModel()
+            .withTracerProvider(new TracerProviderModel().withSampler(userSampler))
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "solarwinds",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_SERVICE_KEY.getConfigFileKey(),
+                                        "token:service")
+                                    .withAdditionalProperty(
+                                        ConfigProperty.AGENT_COLLECTOR.getConfigFileKey(),
+                                        "apm.collector.com"))));
+
+    doNothing()
+        .when(declarativeConfigurationCustomizerMock)
+        .addModelCustomizer(functionArgumentCaptor.capture());
+
+    tested.customize(declarativeConfigurationCustomizerMock);
+    functionArgumentCaptor.getValue().apply(openTelemetryConfigurationModel);
+
+    TracerProviderModel tracerProvider = openTelemetryConfigurationModel.getTracerProvider();
+    SamplerModel sampler = tracerProvider.getSampler();
+
+    assertNull(sampler.getAdditionalProperties().get(SamplerComponentProvider.COMPONENT_NAME));
+    assertTrue(sampler.getAdditionalProperties().containsKey("cel"));
+  }
+
+  @Test
   void logsNotConfiguredWhenLoggerProviderAbsent() {
     OpenTelemetryConfigurationModel openTelemetryConfigurationModel =
         new OpenTelemetryConfigurationModel()

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -80,7 +80,11 @@ tasks {
     filesMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+
     exclude("**/module-info.class")
+    filesMatching(listOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/NOTICE", "META-INF/NOTICE.txt")) {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 
     // exclude known bootstrap dependencies - they can't appear in the inst/ directory
     dependencies {


### PR DESCRIPTION
## Summary

Allow users to provide their own sampler (e.g., CEL sampler) instead of forcing the SolarwindsSampler. Remove the JDK version check in the Lambda extension. Fix duplicate META-INF license file warnings in shadow JARs.

## Details

### User-provided sampler support

Previously, the `AgentListener` implementations (`SolarwindsAgentListener`, `LambdaAgentListener`) checked at startup whether the configured sampler was an instance of `SolarwindsSampler`. If not, they disabled the agent entirely and shut down the SDK. This prevented users from using alternative samplers (like the OpenTelemetry CEL sampler) while still benefiting from the rest of the SolarWinds extensions (exporters, propagators, span processors).

This change removes the `isUsingSolarwindsSampler` runtime check and the `setAgentEnabled` method that allowed it to ratchet the agent off. The agent now starts its background tasks (settings reader, HTTP settings delegate, shutdown hooks) whenever `isAgentEnabled()` is true, regardless of which sampler is in use.

On the declarative configuration side, `SharedConfigCustomizerProvider.addSampler()` now checks whether a sampler is already configured before injecting the default `SolarwindsSampler`. If the user has declared a sampler in their config file, it is preserved.

The `opentelemetry-cel-sampler` contrib library is added as a dependency so users can configure CEL-based sampling rules directly in their OpenTelemetry config file without writing a custom extension.

### JDK version check removal in Lambda

The Lambda configuration provider previously gated initialization on `JavaRuntimeVersionChecker.isJdkVersionSupported()`. This check is no longer needed because AWS Lambda runtimes guarantee a supported JDK version. Removing it simplifies the startup path and eliminates a dependency on the version checker in the Lambda module.

### META-INF duplicate file fix

Shadow/fat JAR tasks in `agent`, `agent-lambda`, and `testing/agent-for-testing` now use `DuplicatesStrategy.EXCLUDE` for `META-INF/LICENSE*` and `META-INF/NOTICE*` files to suppress build warnings from multiple dependencies bundling the same license files.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
