### PR TITLE
remove cloud relocation because it's not needed anymore

### DIFF
--- a/buildSrc/src/main/kotlin/solarwinds.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/solarwinds.shadow-conventions.gradle.kts
@@ -58,10 +58,6 @@ tasks.withType<ShadowJar>().configureEach {
   relocate("android.annotation", "com.solarwinds.joboe.shaded.android.annotation")
   relocate("javax.annotation", "com.solarwinds.joboe.shaded.javax.annotation")
 
-  relocate("cloud", "com.solarwinds.joboe.shaded.cloud")
-  relocate("google", "com.solarwinds.joboe.shaded.google2")
-  relocate("com.google", "com.solarwinds.joboe.shaded.google")
-
   relocate("javax.xml", "com.solarwinds.joboe.shaded.javax.xml")
   relocate("io.grpc", "com.solarwinds.joboe.shaded.io.grpc")
   relocate("io.netty", "com.solarwinds.joboe.shaded.io.netty")
@@ -71,4 +67,5 @@ tasks.withType<ShadowJar>().configureEach {
   relocate("org.jspecify", "com.solarwinds.joboe.shaded.org.jspecify")
 
   relocate("org.codehaus.mojo", "com.solarwinds.joboe.shaded.org.codehaus.mojo")
+  relocate("google", "com.solarwinds.joboe.shaded.google2")
 }


### PR DESCRIPTION
## Summary

Remove the `cloud` package relocation from the shadow JAR configuration and deduplicate the `com.google` relocation rule.

## Details

The `cloud` relocation (`cloud` → `com.solarwinds.joboe.shaded.cloud`) was inadvertently rewriting OpenTelemetry semantic convention attribute names that contain `cloud` (e.g., `cloud.platform`, `cloud.provider`) into shaded equivalents at build time. This caused the agent to emit incorrect attribute keys at runtime.

Removing this relocation fixes the attribute name corruption. No actual classes under a bare `cloud.*` package exist in the dependency tree, so the rule served no useful shading purpose.

Additionally, the `com.google` relocation in this block was a duplicate — it already exists earlier in the file. The `google` relocation (for proto-generated classes outside the `com.google` namespace) is retained and moved to the end of the relocation list for clarity.

## Changes

- Removed `cloud` → `com.solarwinds.joboe.shaded.cloud` relocation
- Removed duplicate `com.google` → `com.solarwinds.joboe.shaded.google` relocation
- Moved `google` → `com.solarwinds.joboe.shaded.google2` relocation to end of block


**Test Plan**:

Manual verification

**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
