### PR TITLE
Fix - use flags api for trace flags

### DIFF
--- a/instrumentation/instrumentation-shared/src/main/java/com/solarwinds/opentelemetry/instrumentation/TraceContextInjector.java
+++ b/instrumentation/instrumentation-shared/src/main/java/com/solarwinds/opentelemetry/instrumentation/TraceContextInjector.java
@@ -33,9 +33,13 @@ public class TraceContextInjector {
       return sql;
     }
 
-    String flags = "01"; // only inject into sampled requests
     String traceContext =
-        "00-" + spanContext.getTraceId() + "-" + spanContext.getSpanId() + "-" + flags;
+        "00-"
+            + spanContext.getTraceId()
+            + "-"
+            + spanContext.getSpanId()
+            + "-"
+            + spanContext.getTraceFlags().asHex();
 
     String tag = String.format("/*traceparent='%s'*/", traceContext);
     span.setAttribute("sw.query_tag", tag);

--- a/instrumentation/instrumentation-shared/src/test/java/com/solarwinds/opentelemetry/instrumentation/TraceContextInjectorTest.java
+++ b/instrumentation/instrumentation-shared/src/test/java/com/solarwinds/opentelemetry/instrumentation/TraceContextInjectorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ class TraceContextInjectorTest {
       when(spanContextMock.getTraceId()).thenReturn(traceId);
 
       when(spanContextMock.getSpanId()).thenReturn(spanId);
+      when(spanContextMock.getTraceFlags()).thenReturn(TraceFlags.getSampled());
 
       String actual = TraceContextInjector.inject(Context.current(), sql);
       String expected = String.format("/*traceparent='00-%s-%s-01'*/ %s", traceId, spanId, sql);


### PR DESCRIPTION
## Summary

Replace the hardcoded `"01"` trace-flags value in the `traceparent` SQL comment injection with the OpenTelemetry `SpanContext.getTraceFlags().asHex()` API to correctly propagate all valid flag values.

## Details

The `TraceContextInjector` builds a W3C `traceparent` header and injects it as a SQL comment for query tagging. Previously, the trace-flags field was hardcoded to `"01"`. This is incorrect because trace flags today can be `00`, `01`, `02`, or `03`. The `isSampled()` guard ensures only sampled spans reach this code, but a sampled span can have flags `01` or `03` — the old hardcoded value would silently drop the second bit.

Using `getTraceFlags().asHex()` ensures the injected `traceparent` accurately reflects the span's actual flags.

The test is updated to stub `getTraceFlags()` on the mocked `SpanContext`, returning `TraceFlags.getSampled()`.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
