### PR TITLE
Internal - Use pre-computed transaction name from span attributes

### DIFF
--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGenerator.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGenerator.java
@@ -16,11 +16,11 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.LEGACY_TRANSACTION_NAME_KEY;
+import static com.solarwinds.opentelemetry.extensions.SharedNames.TRANSACTION_NAME_KEY;
 
 import com.solarwinds.joboe.logging.Logger;
 import com.solarwinds.joboe.logging.LoggerFactory;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.LongHistogram;
@@ -37,10 +37,6 @@ import io.opentelemetry.semconv.HttpAttributes;
 
 public class InboundMeasurementMetricsGenerator implements ExtendedSpanProcessor {
   private LongHistogram responseTime;
-  private static final AttributeKey<String> TRANSACTION_NAME_KEY =
-      stringKey(SharedNames.TRANSACTION_NAME_KEY);
-  private static final AttributeKey<String> LEGACY_TRANSACTION_NAME_KEY =
-      stringKey("TransactionName");
 
   private static final Logger logger = LoggerFactory.getLogger();
 

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SharedNames.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SharedNames.java
@@ -16,12 +16,14 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
 public final class SharedNames {
   private SharedNames() {}
 
   public static final String COMPONENT_NAME = "solarwinds";
-
-  public static final String TRANSACTION_NAME_KEY = "sw.transaction";
 
   public static final String SPAN_STACKTRACE_FILTER_CLASS =
       "com.solarwinds.opentelemetry.extensions.SpanStacktraceFilter";
@@ -33,4 +35,9 @@ public final class SharedNames {
   public static final String SW_OTEL_PROXY_HOST_KEY = "sw.otel.exporter.proxy.host";
 
   public static final String SW_OTEL_PROXY_PORT_KEY = "sw.otel.exporter.proxy.port";
+
+  public static final AttributeKey<String> TRANSACTION_NAME_KEY = stringKey("sw.transaction");
+
+  public static final AttributeKey<String> LEGACY_TRANSACTION_NAME_KEY =
+      stringKey("TransactionName");
 }

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
@@ -16,6 +16,8 @@
 
 package com.solarwinds.opentelemetry.extensions;
 
+import static com.solarwinds.opentelemetry.extensions.SharedNames.TRANSACTION_NAME_KEY;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.solarwinds.joboe.config.ConfigManager;
@@ -164,8 +166,13 @@ public class TransactionNameManager {
 
   static String buildTransactionName(SpanData spanData) {
     Attributes spanAttributes = spanData.getAttributes();
-    String custName = CustomTransactionNameDict.get(spanData.getTraceId());
+    String transactionName = spanAttributes.get(TRANSACTION_NAME_KEY);
+    if (transactionName != null && !transactionName.isEmpty()) {
+      logger.trace(String.format("Using pre-computed transaction name -> %s", transactionName));
+      return transactionName;
+    }
 
+    String custName = CustomTransactionNameDict.get(spanData.getTraceId());
     if (custName != null) {
       logger.trace(String.format("Using custom transaction name -> %s", custName));
       return custName;
@@ -201,7 +208,7 @@ public class TransactionNameManager {
 
     if (customTransactionNamePattern
         != null) { // try forming transaction name by the custom configured pattern
-      String transactionName =
+      transactionName =
           getTransactionNameByUrlAndPattern(
               path, customTransactionNamePattern, false, CUSTOM_TRANSACTION_NAME_PATTERN_SEPARATOR);
 

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGeneratorTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/InboundMeasurementMetricsGeneratorTest.java
@@ -129,9 +129,7 @@ class InboundMeasurementMetricsGeneratorTest {
                         && Boolean.FALSE.equals(
                             attributes.get(AttributeKey.booleanKey("sw.is_error")))
                         && TransactionNameManager.getTransactionName(testSpanData)
-                            .equals(
-                                attributes.get(
-                                    AttributeKey.stringKey(SharedNames.TRANSACTION_NAME_KEY))));
+                            .equals(attributes.get(SharedNames.TRANSACTION_NAME_KEY)));
 
     assertTrue(allMatch);
   }
@@ -170,9 +168,7 @@ class InboundMeasurementMetricsGeneratorTest {
                         && Boolean.TRUE.equals(
                             attributes.get(AttributeKey.booleanKey("sw.is_error")))
                         && TransactionNameManager.getTransactionName(testSpanData)
-                            .equals(
-                                attributes.get(
-                                    AttributeKey.stringKey(SharedNames.TRANSACTION_NAME_KEY))));
+                            .equals(attributes.get(SharedNames.TRANSACTION_NAME_KEY)));
 
     assertTrue(allMatch);
   }

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/TransactionNameManagerTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/TransactionNameManagerTest.java
@@ -1,0 +1,83 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.opentelemetry.extensions;
+
+import static com.solarwinds.opentelemetry.extensions.SharedNames.TRANSACTION_NAME_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import org.junit.jupiter.api.Test;
+
+class TransactionNameManagerTest {
+
+  @Test
+  void buildTransactionNameReturnsPreComputedNameFromSpanAttribute() {
+    TestSpanData spanData =
+        TestSpanData.builder()
+            .setName("test")
+            .setKind(SpanKind.SERVER)
+            .setStartEpochNanos(0)
+            .setEndEpochNanos(10_000_000)
+            .setHasEnded(true)
+            .setStatus(StatusData.ok())
+            .setAttributes(Attributes.of(TRANSACTION_NAME_KEY, "pre-computed-name"))
+            .build();
+
+    String result = TransactionNameManager.buildTransactionName(spanData);
+    assertEquals("pre-computed-name", result);
+  }
+
+  @Test
+  void buildTransactionNameFallsBackWhenPreComputedNameIsEmpty() {
+    TestSpanData spanData =
+        TestSpanData.builder()
+            .setName("test")
+            .setKind(SpanKind.SERVER)
+            .setStartEpochNanos(0)
+            .setEndEpochNanos(10_000_000)
+            .setHasEnded(true)
+            .setStatus(StatusData.ok())
+            .setAttributes(Attributes.of(TRANSACTION_NAME_KEY, ""))
+            .build();
+
+    String result = TransactionNameManager.buildTransactionName(spanData);
+    assertNotEquals("", result);
+  }
+
+  @Test
+  void buildTransactionNameFallsBackWhenTransactionNameAttributeIsAbsent() {
+    TestSpanData spanData =
+        TestSpanData.builder()
+            .setName("test")
+            .setKind(SpanKind.SERVER)
+            .setStartEpochNanos(0)
+            .setEndEpochNanos(10_000_000)
+            .setHasEnded(true)
+            .setStatus(StatusData.ok())
+            .setAttributes(Attributes.empty())
+            .build();
+
+    String result = TransactionNameManager.buildTransactionName(spanData);
+    assertNotNull(result);
+    assertNotEquals("", result);
+  }
+}


### PR DESCRIPTION
## TLDR

Short-circuit `buildTransactionName` when a `sw.transaction` attribute already exists on the span, avoiding redundant name resolution. Consolidate `TRANSACTION_NAME_KEY` and `LEGACY_TRANSACTION_NAME_KEY` into `SharedNames` as typed `AttributeKey<String>` constants.

## Motivation

`InboundMeasurementMetricsGenerator.onEnding` computes and sets the transaction name on the span via `setAttribute`. However, if the span is later read again (e.g., by metrics recording in `onEnd`), `buildTransactionName` re-executes the full resolution chain — custom dictionary lookup, naming scheme, handler name, http.route, URL pattern extraction — even though the answer is already sitting in the span's attributes. This is wasted work.

## What changed

**Early-return on pre-computed name:** `buildTransactionName` now checks `spanAttributes.get(TRANSACTION_NAME_KEY)` first. If a non-null, non-empty value exists, it returns immediately. This makes the already-set `sw.transaction` attribute the highest-priority source in the resolution chain, ahead of custom dictionary names, naming schemes, and URL-based derivation.

**Type promotion of shared constants:** `TRANSACTION_NAME_KEY` was previously a plain `String` in `SharedNames` and each consumer independently wrapped it with `AttributeKey.stringKey(...)`. It is now declared as `AttributeKey<String>` directly, eliminating the repeated wrapping. `LEGACY_TRANSACTION_NAME_KEY` (`"TransactionName"`) was a private constant in `InboundMeasurementMetricsGenerator` and is now shared alongside it.

**Resolution priority order** (unchanged except for the new first step):
1. Pre-computed `sw.transaction` span attribute (new)
2. Custom transaction name dictionary (`CustomTransactionNameDict`)
3. Naming scheme (`NamingScheme.createName`)
4. Handler name (e.g., Spring MVC)
5. `http.route`
6. URL pattern extraction
7. Span name fallback

## Tests

Three new tests cover the pre-computed name path:
- Returns pre-computed name when `sw.transaction` attribute is present
- Falls back to standard resolution when attribute value is empty
- Falls back to standard resolution when attribute is absent


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
