### PR TITLE
New -  Enable upstream resource detectors for Azure and AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .gradle/
 .DS_Store
 .idea/
+buildSrc/.kotlin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins{
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
-val swoAgentVersion = "3.2.0"
+val swoAgentVersion = "3.2.1"
 extra["swoAgentVersion"] = swoAgentVersion
 group = "com.solarwinds"
 version = if (System.getenv("SNAPSHOT_BUILD").toBoolean()) "$swoAgentVersion-SNAPSHOT" else swoAgentVersion

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/HostIdResourceProvider.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/HostIdResourceProvider.java
@@ -29,4 +29,9 @@ public class HostIdResourceProvider implements ResourceProvider {
   public Resource createResource(ConfigProperties configProperties) {
     return Resource.create(HostIdResourceUtil.createAttribute());
   }
+
+  @Override
+  public int order() {
+    return Integer.MIN_VALUE;
+  }
 }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsPropertiesSupplier.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsPropertiesSupplier.java
@@ -43,6 +43,8 @@ public class SolarwindsPropertiesSupplier implements Supplier<Map<String, String
           "base2_exponential_bucket_histogram");
       PROPERTIES.put(
           "otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics", "true");
+      PROPERTIES.put("otel.resource.providers.azure.enabled", "true");
+      PROPERTIES.put("otel.resource.providers.aws.enabled", "true");
     } else {
       PROPERTIES.put("otel.sdk.disabled", "true");
     }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtil.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtil.java
@@ -21,80 +21,28 @@ import com.solarwinds.joboe.core.util.ServerHostInfoReader;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.semconv.ContainerAttributes;
 import io.opentelemetry.semconv.K8sAttributes;
-import io.opentelemetry.semconv.ServiceAttributes;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 
 public final class HostIdResourceUtil {
   private HostIdResourceUtil() {}
 
   public static Attributes createAttribute() {
     AttributesBuilder builder = Attributes.builder();
-
     HostId hostId = ServerHostInfoReader.INSTANCE.getHostId();
-    builder.put(ContainerAttributes.CONTAINER_ID, hostId.getDockerContainerId());
-    builder.put(ProcessIncubatingAttributes.PROCESS_PID, (long) hostId.getPid());
     builder.put(AttributeKey.stringArrayKey("mac.addresses"), hostId.getMacAddresses());
 
-    builder.put(
-        AttributeKey.stringKey("azure.app.service.instance.id"),
-        hostId.getAzureAppServiceInstanceId());
     builder.put(HostIncubatingAttributes.HOST_ID, hostId.getHerokuDynoId());
     builder.put(AttributeKey.stringKey("sw.uams.client.id"), hostId.getUamsClientId());
-    builder.put(AttributeKey.stringKey("uuid"), hostId.getUuid());
-    builder.put(ServiceAttributes.SERVICE_INSTANCE_ID, hostId.getUuid());
-
     HostId.K8sMetadata k8sMetadata = hostId.getK8sMetadata();
+
     if (k8sMetadata != null) {
       builder.put(K8sAttributes.K8S_POD_UID, k8sMetadata.getPodUid());
       builder.put(K8sAttributes.K8S_NAMESPACE_NAME, k8sMetadata.getNamespace());
       builder.put(K8sAttributes.K8S_POD_NAME, k8sMetadata.getPodName());
     }
 
-    HostId.AwsMetadata awsMetadata = hostId.getAwsMetadata();
-    if (awsMetadata != null) {
-      builder.put(HostIncubatingAttributes.HOST_ID, awsMetadata.getHostId());
-      builder.put(HostIncubatingAttributes.HOST_NAME, awsMetadata.getHostName());
-      builder.put(CloudIncubatingAttributes.CLOUD_PROVIDER, awsMetadata.getCloudProvider());
-
-      builder.put(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, awsMetadata.getCloudAccountId());
-      builder.put(CloudIncubatingAttributes.CLOUD_PLATFORM, awsMetadata.getCloudPlatform());
-      builder.put(
-          CloudIncubatingAttributes.CLOUD_AVAILABILITY_ZONE,
-          awsMetadata.getCloudAvailabilityZone());
-
-      builder.put(CloudIncubatingAttributes.CLOUD_REGION, awsMetadata.getCloudRegion());
-      builder.put(HostIncubatingAttributes.HOST_IMAGE_ID, awsMetadata.getHostImageId());
-      builder.put(HostIncubatingAttributes.HOST_TYPE, awsMetadata.getHostType());
-    }
-
-    HostId.AzureVmMetadata azureVmMetadata = hostId.getAzureVmMetadata();
-    if (azureVmMetadata != null) {
-      builder.put(HostIncubatingAttributes.HOST_ID, azureVmMetadata.getHostId());
-      builder.put(HostIncubatingAttributes.HOST_NAME, azureVmMetadata.getHostName());
-      builder.put(CloudIncubatingAttributes.CLOUD_PROVIDER, azureVmMetadata.getCloudProvider());
-
-      builder.put(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, azureVmMetadata.getCloudAccountId());
-      builder.put(CloudIncubatingAttributes.CLOUD_PLATFORM, azureVmMetadata.getCloudPlatform());
-      builder.put(CloudIncubatingAttributes.CLOUD_REGION, azureVmMetadata.getCloudRegion());
-
-      builder.put(AttributeKey.stringKey("azure.vm.name"), azureVmMetadata.getAzureVmName());
-      builder.put(AttributeKey.stringKey("azure.vm.size"), azureVmMetadata.getAzureVmSize());
-      builder.put(
-          AttributeKey.stringKey("azure.resourcegroup.name"),
-          azureVmMetadata.getAzureResourceGroupName());
-
-      builder.put(
-          AttributeKey.stringKey("azure.vm.scaleset.name"),
-          azureVmMetadata.getAzureVmScaleSetName());
-    }
-
     builder.put(HostIncubatingAttributes.HOST_NAME, hostId.getHostname());
-    builder.put(CloudIncubatingAttributes.CLOUD_AVAILABILITY_ZONE, hostId.getEc2AvailabilityZone());
-    builder.put(HostIncubatingAttributes.HOST_ID, hostId.getEc2InstanceId());
     return builder.build();
   }
 }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReader.java
@@ -56,7 +56,10 @@ public class HttpSettingsReader implements SettingsReader {
 
     String tokenHeader = String.format("Bearer %s", apiToken);
     Settings fetchedSettings = delegate.fetchSettings(settingsUrl, tokenHeader);
-    logger.debug(String.format("Got settings from http: %s", fetchedSettings));
+    logger.debug(
+        String.format(
+            "Got settings from http: %s, serviceName: %s, hostname: %s",
+            fetchedSettings, serviceName, hostname));
 
     return fetchedSettings;
   }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/CustomConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/CustomConfigCustomizerProvider.java
@@ -67,7 +67,11 @@ public class CustomConfigCustomizerProvider implements DeclarativeConfigurationC
       detectors = new ArrayList<>();
     }
 
-    List<ExperimentalResourceDetectorModel> newDetectors = new ArrayList<>(detectors);
+    // Ordering matters: SWO detectors are added first, then upstream detectors (e.g. aws/azure)
+    // are appended so they run last. With last-writer-wins merge semantics this lets upstream
+    // cloud attributes override our host-id attributes. Do not reorder without accounting for
+    // which detector's attributes should survive the merge.
+    List<ExperimentalResourceDetectorModel> newDetectors = new ArrayList<>();
     newDetectors.add(
         new ExperimentalResourceDetectorModel()
             .withAdditionalProperty(
@@ -79,6 +83,8 @@ public class CustomConfigCustomizerProvider implements DeclarativeConfigurationC
             .withAdditionalProperty(
                 HostIdResourceComponentProvider.COMPONENT_NAME,
                 new ExperimentalResourceDetectorPropertyModel()));
+
+    newDetectors.addAll(detectors);
     detectionDevelopment.withDetectors(newDetectors);
   }
 

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/ResourceComponentProvider.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/provider/ResourceComponentProvider.java
@@ -33,7 +33,11 @@ public class ResourceComponentProvider implements ComponentProvider {
 
   public static final String COMPONENT_NAME = "swo/resource";
 
-  @Getter @Setter private static Resource resource = null;
+  // Accumulated statically: create() merges into this field in place, and
+  // HostIdResourceComponentProvider reads it via getResource().merge(...). Assumes create() is
+  // invoked once; merging identical attributes is idempotent, but any new writer of this field
+  // must be aware the result is order-dependent.
+  @Getter @Setter private static Resource resource = Resource.getDefault();
 
   @Override
   public Class<Resource> getType() {
@@ -50,7 +54,7 @@ public class ResourceComponentProvider implements ComponentProvider {
     Attributes resourceAttributes =
         Attributes.of(moduleKey, "apm", versionKey, BuildConfig.SOLARWINDS_AGENT_VERSION);
 
-    resource = Resource.create(resourceAttributes);
+    resource = resource.merge(Resource.create(resourceAttributes));
     return resource;
   }
 }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtilTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtilTest.java
@@ -18,19 +18,16 @@ package com.solarwinds.opentelemetry.extensions.config;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class HostIdResourceUtilTest {
   @Test
   void testCreateAttributes() {
     Attributes attribute = HostIdResourceUtil.createAttribute();
-    Long pid = attribute.get(ProcessIncubatingAttributes.PROCESS_PID);
-    String hostname = attribute.get(HostIncubatingAttributes.HOST_NAME);
-
-    assertNotNull(pid);
-    assertNotNull(hostname);
+    List<String> macAddresses = attribute.get(AttributeKey.stringArrayKey("mac.addresses"));
+    assertNotNull(macAddresses);
   }
 }

--- a/libs/shared/build.gradle.kts
+++ b/libs/shared/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
   implementation("io.opentelemetry.contrib:opentelemetry-cel-sampler") {
     exclude(module = "opentelemetry-sdk", group = "io.opentelemetry") // the agent includes this
     exclude(group = "com.google.code.findbugs", module = "annotations")
+    exclude(group = "com.google.guava", module = "guava")
+    exclude(group = "com.google.protobuf")
   }
 
   implementation("org.json:json")


### PR DESCRIPTION
## Summary

Removes custom AWS and Azure metadata collection from `HostIdResourceUtil` and delegates that work to the upstream OpenTelemetry resource detectors instead. Upstream detectors are explicitly enabled via configuration properties and are ordered after SWO detectors so their cloud attributes win under last-writer-wins merge semantics. Also fixes a subtle null-initialization bug in `ResourceComponentProvider` that could cause a NPE when `merge` is called with the detectors are reordered.

---

## What changed and why

### Delegating AWS/Azure detection to upstream OTel

The agent was manually querying AWS EC2 and Azure VM metadata endpoints inside `HostIdResourceUtil` and mapping the results to OTel semantic-convention attributes (`cloud.*`, `host.*`, etc.). The upstream OTel Java agent already ships resource detectors that do exactly this. Maintaining a parallel implementation creates a divergence risk as the OTel semconv evolves.

The detectors are now enabled unconditionally via two properties added to `SolarwindsPropertiesSupplier`:

```
otel.resource.providers.azure.enabled = true
otel.resource.providers.aws.enabled   = true
```

All AWS- and Azure-specific attribute writes were removed from `HostIdResourceUtil`. What remains are attributes the upstream detectors don't cover: MAC addresses, Heroku dyno ID, and UAMS client ID.

### Detector ordering and merge semantics

OTel resource merging is last-writer-wins. To let upstream cloud attributes (from the now-enabled AWS/Azure detectors) override any overlapping host-id attributes from SWO, SWO detectors must run *before* upstream ones.

`CustomConfigCustomizerProvider` previously built the detector list as `new ArrayList<>(detectors)` (upstream first) and then prepended SWO entries — meaning SWO attributes won the merge. The list construction is now inverted: SWO detectors are inserted first, then `detectors` (the upstream list) is appended. Upstream cloud attributes now overwrite SWO's when there is a conflict.

`HostIdResourceProvider.order()` returns `Integer.MIN_VALUE` so that, in the non-declarative config path, the SWO provider is also sorted to run earliest.

### `ResourceComponentProvider` null-safety

The static `resource` field was initialized to `null`. `create()` called `resource.merge(...)`, which would NPE on first invocation. Changed the initializer to `Resource.getDefault()` so the merge chain starts from a safe baseline.

### Dependency exclusions

Excluded `guava` and `protobuf` from the `opentelemetry-cel-sampler` transitive graph to prevent version conflicts with dependencies already provided by the agent.

### Debug logging

`HttpSettingsReader` now includes `serviceName` and `hostname` alongside fetched settings in the debug log, making it easier to correlate settings fetches with the reporting identity during troubleshooting.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
