### PR TITLE
Internal - Remove Host Name from Settings URL

### DIFF
--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtil.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HostIdResourceUtil.java
@@ -42,7 +42,6 @@ public final class HostIdResourceUtil {
       builder.put(K8sAttributes.K8S_POD_NAME, k8sMetadata.getPodName());
     }
 
-    builder.put(HostIncubatingAttributes.HOST_NAME, hostId.getHostname());
     return builder.build();
   }
 }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReader.java
@@ -23,8 +23,6 @@ import com.solarwinds.joboe.core.settings.SettingsReader;
 import com.solarwinds.joboe.logging.Logger;
 import com.solarwinds.joboe.logging.LoggerFactory;
 import com.solarwinds.joboe.sampling.Settings;
-import com.solarwinds.opentelemetry.extensions.ResourceArbiter;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,15 +49,12 @@ public class HttpSettingsReader implements SettingsReader {
     String serviceName = ServiceKeyUtils.getServiceName(serviceKey);
 
     String apiToken = ServiceKeyUtils.getApiKey(serviceKey);
-    String hostname = ResourceArbiter.resource().getAttribute(HostIncubatingAttributes.HOST_NAME);
-    String settingsUrl = String.format("%s/v1/settings/%s/%s", collectorUrl, serviceName, hostname);
+    String settingsUrl = String.format("%s/v1/settings/%s", collectorUrl, serviceName);
 
     String tokenHeader = String.format("Bearer %s", apiToken);
     Settings fetchedSettings = delegate.fetchSettings(settingsUrl, tokenHeader);
     logger.debug(
-        String.format(
-            "Got settings from http: %s, serviceName: %s, hostname: %s",
-            fetchedSettings, serviceName, hostname));
+        String.format("Got settings from http: %s, serviceName: %s", fetchedSettings, serviceName));
 
     return fetchedSettings;
   }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReaderTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReaderTest.java
@@ -19,8 +19,6 @@ package com.solarwinds.opentelemetry.extensions.config;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,15 +26,11 @@ import com.solarwinds.joboe.config.ConfigManager;
 import com.solarwinds.joboe.config.ConfigProperty;
 import com.solarwinds.joboe.config.InvalidConfigException;
 import com.solarwinds.joboe.sampling.Settings;
-import com.solarwinds.opentelemetry.extensions.ResourceCustomizer;
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,184 +51,124 @@ class HttpSettingsReaderTest {
   void testGetSettings_UrlWithHttps() throws InvalidConfigException {
     String collectorUrl = "https://apm.collector.na-01.cloud.solarwinds.com";
     String serviceKey = "test-api-key:test-service";
-    String hostname = "test-hostname";
 
     String expectedUrl =
-        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service/test-hostname";
+        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service";
     String expectedTokenHeader = "Bearer test-api-key";
     ConfigManager.setConfig(ConfigProperty.AGENT_COLLECTOR, collectorUrl);
-
     ConfigManager.setConfig(ConfigProperty.AGENT_SERVICE_KEY, serviceKey);
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
 
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
+    Settings result = tested.getSettings();
 
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
-      Settings result = tested.getSettings();
-
-      assertNotNull(result);
-      assertEquals(mockSettings, result);
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertNotNull(result);
+    assertEquals(mockSettings, result);
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 
   @Test
   void testGetSettings_UrlWithoutHttps() throws InvalidConfigException {
     String collectorUrl = "apm.collector.na-01.cloud.solarwinds.com";
     String serviceKey = "test-api-key:test-service";
-    String hostname = "test-hostname";
 
     String expectedUrl =
-        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service/test-hostname";
+        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service";
     String expectedTokenHeader = "Bearer test-api-key";
     ConfigManager.setConfig(ConfigProperty.AGENT_COLLECTOR, collectorUrl);
-
     ConfigManager.setConfig(ConfigProperty.AGENT_SERVICE_KEY, serviceKey);
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
 
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
-      Settings result = tested.getSettings();
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
+    Settings result = tested.getSettings();
 
-      assertNotNull(result);
-      assertEquals(mockSettings, result);
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertNotNull(result);
+    assertEquals(mockSettings, result);
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 
   @Test
   void testGetSettings_UrlWithHttp() throws InvalidConfigException {
     String collectorUrl = "http://apm.collector.na-01.cloud.solarwinds.com";
     String serviceKey = "test-api-key:test-service";
-    String hostname = "test-hostname";
 
     String expectedUrl =
-        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service/test-hostname";
+        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service";
     String expectedTokenHeader = "Bearer test-api-key";
     ConfigManager.setConfig(ConfigProperty.AGENT_COLLECTOR, collectorUrl);
-
     ConfigManager.setConfig(ConfigProperty.AGENT_SERVICE_KEY, serviceKey);
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
 
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
+    Settings result = tested.getSettings();
 
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
-      Settings result = tested.getSettings();
-
-      assertNotNull(result);
-      assertEquals(mockSettings, result);
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertNotNull(result);
+    assertEquals(mockSettings, result);
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 
   @Test
   void testGetSettings_WithDefaultValues() {
-    String hostname = "test-hostname";
     String expectedUrl =
-        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/unknown-java/test-hostname";
+        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/unknown-java";
     String expectedTokenHeader = "Bearer ";
 
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
+    Settings result = tested.getSettings();
 
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
-
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
-      Settings result = tested.getSettings();
-
-      assertNotNull(result);
-      assertEquals(mockSettings, result);
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertNotNull(result);
+    assertEquals(mockSettings, result);
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 
   @Test
   void testGetSettings_WithCustomServiceKey() throws InvalidConfigException {
     String collectorUrl = "custom.collector.com";
     String serviceKey = "my-api-key:my-service";
-    String hostname = "prod-server";
 
-    String expectedUrl = "https://custom.collector.com/v1/settings/my-service/prod-server";
+    String expectedUrl = "https://custom.collector.com/v1/settings/my-service";
     String expectedTokenHeader = "Bearer my-api-key";
     ConfigManager.setConfig(ConfigProperty.AGENT_COLLECTOR, collectorUrl);
-
     ConfigManager.setConfig(ConfigProperty.AGENT_SERVICE_KEY, serviceKey);
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
 
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
+    Settings result = tested.getSettings();
 
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
-      Settings result = tested.getSettings();
-
-      assertNotNull(result);
-      assertEquals(mockSettings, result);
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertNotNull(result);
+    assertEquals(mockSettings, result);
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 
   @Test
   void testGetSettings_DelegateThrowsException() throws InvalidConfigException {
     String collectorUrl = "https://apm.collector.na-01.cloud.solarwinds.com";
     String serviceKey = "test-api-key:test-service";
-    String hostname = "test-hostname";
     String expectedUrl =
-        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service/test-hostname";
+        "https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/test-service";
     String expectedTokenHeader = "Bearer test-api-key";
 
     ConfigManager.setConfig(ConfigProperty.AGENT_COLLECTOR, collectorUrl);
     ConfigManager.setConfig(ConfigProperty.AGENT_SERVICE_KEY, serviceKey);
 
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader))
+        .thenThrow(new RuntimeException("Network error"));
 
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader))
-          .thenThrow(new RuntimeException("Network error"));
-
-      assertThrows(RuntimeException.class, () -> tested.getSettings());
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertThrows(RuntimeException.class, () -> tested.getSettings());
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 
   @Test
   void testGetSettings_UrlWithPortAndPath() throws InvalidConfigException {
     String collectorUrl = "https://custom.collector.com:8080/api";
     String serviceKey = "test-key:test-app";
-    String hostname = "server1";
-    String expectedUrl = "https://custom.collector.com:8080/api/v1/settings/test-app/server1";
+    String expectedUrl = "https://custom.collector.com:8080/api/v1/settings/test-app";
     String expectedTokenHeader = "Bearer test-key";
 
     ConfigManager.setConfig(ConfigProperty.AGENT_COLLECTOR, collectorUrl);
     ConfigManager.setConfig(ConfigProperty.AGENT_SERVICE_KEY, serviceKey);
 
-    try (MockedStatic<ResourceCustomizer> resourceCustomizerMock =
-        mockStatic(ResourceCustomizer.class)) {
-      Resource mockResource = mock(Resource.class);
-      resourceCustomizerMock.when(ResourceCustomizer::getResource).thenReturn(mockResource);
-      when(mockResource.getAttribute(HostIncubatingAttributes.HOST_NAME)).thenReturn(hostname);
+    when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
+    Settings result = tested.getSettings();
 
-      when(delegate.fetchSettings(expectedUrl, expectedTokenHeader)).thenReturn(mockSettings);
-      Settings result = tested.getSettings();
-
-      assertNotNull(result);
-      assertEquals(mockSettings, result);
-      verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
-    }
+    assertNotNull(result);
+    assertEquals(mockSettings, result);
+    verify(delegate).fetchSettings(expectedUrl, expectedTokenHeader);
   }
 }


### PR DESCRIPTION
## Summary

The agent's `getSettings` HTTP call previously appended the hostname as a path segment (`/v1/settings/{service}/{hostname}`). This change removes the hostname from that URL, making the endpoint `/v1/settings/{service}`.

## What changed

**Settings URL path simplified**

The `HttpSettingsReader` no longer looks up the host name from `ResourceArbiter` to embed it in the settings URL. The `HOST_NAME` attribute was being read from the resolved OTel resource and appended as a trailing path segment, tying settings fetches to host identity at the URL level. Removing it decouples settings retrieval from host identity.

**`HostIdResourceUtil` no longer emits `HOST_NAME`**

The same attribute was being injected into the resource identity map built by `HostIdResourceUtil`. That line is removed, so the host name is no longer part of the identity attributes contributed by this utility.

**Rationale**

The collector's `/v1/settings` endpoint does not require the hostname in the path as of current specification.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
