### PR TITLE
Internal - Lazy debug/trace logging to cut string-building overhead on disabled log levels

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,34 @@
+# Benchmarks
+
+JMH microbenchmarks for the solarwinds-apm-java project, using the
+[`me.champeau.jmh`](https://github.com/melix/jmh-gradle-plugin) Gradle plugin.
+
+## Running
+
+Run all benchmarks:
+
+```shell
+./gradlew :benchmarks:jmh
+```
+
+Run a specific benchmark by class name (regex matched against the fully
+qualified benchmark name):
+
+```shell
+./gradlew :benchmarks:jmh -Pjmh.include=LoggerLazyLoggingBenchmark
+```
+
+Results are written in CSV format to `benchmarks/build/results/jmh/results.csv`.
+
+## Adding a benchmark
+
+Benchmark sources live under `src/jmh/java`. Add the module under test as a
+`jmh` dependency in `build.gradle.kts`, then write a class annotated with
+JMH's `@Benchmark` and related annotations (see
+`LoggerLazyLoggingBenchmark` for an example).
+
+## Existing benchmarks
+
+- `LoggerLazyLoggingBenchmark` — compares eager (`debug(String)`) vs. lazy
+  (`debug(Supplier<String>)`) logging calls, at both a disabled (`INFO`) and
+  enabled (`DEBUG`) log level.

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id("solarwinds.java-conventions")
+  id("me.champeau.jmh") version "0.7.2"
+}
+
+dependencies {
+  jmh(project(":libs:logging"))
+}
+
+jmh {
+  resultFormat.set("CSV")
+}

--- a/benchmarks/src/jmh/java/com/solarwinds/benchmarks/LoggerLazyLoggingBenchmark.java
+++ b/benchmarks/src/jmh/java/com/solarwinds/benchmarks/LoggerLazyLoggingBenchmark.java
@@ -1,0 +1,144 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.benchmarks;
+
+import com.solarwinds.joboe.logging.LogSetting;
+import com.solarwinds.joboe.logging.Logger;
+import com.solarwinds.joboe.logging.LoggerConfiguration;
+import com.solarwinds.joboe.logging.LoggerFactory;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares eager {@code debug(String)} against lazy {@code debug(Supplier<String>)} logging.
+ *
+ * <p>Four scenarios are driven by the {@link #loggerLevel} parameter:
+ *
+ * <ul>
+ *   <li><b>INFO</b> — the {@code DEBUG} level is <em>disabled</em>. This is where lazy logging pays
+ *       off: the eager call still builds the message via {@code String.format} and throws it away,
+ *       while the lazy call skips construction entirely (the supplier's {@code get()} is never
+ *       invoked).
+ *   <li><b>DEBUG</b> — the {@code DEBUG} level is <em>enabled</em>. Here the message is built in
+ *       both cases, so this measures the overhead lazy logging <em>adds</em> (the capturing-lambda
+ *       allocation) when the work cannot be skipped. This is the cost that justified removing the
+ *       unused supplier overloads on always-enabled levels (info/warn/error/fatal).
+ * </ul>
+ *
+ * <p>Both stdout and stderr streams are disabled on the logger so that the benchmark measures
+ * message construction and dispatch (the {@code shouldLog} guard, lambda allocation, formatting)
+ * rather than console I/O throughput.
+ *
+ * <p>Run with:
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.include=LoggerLazyLoggingBenchmark
+ * }</pre>
+ */
+@Fork(2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Measurement(iterations = 100, time = 1)
+public class LoggerLazyLoggingBenchmark {
+
+  /** "INFO" leaves DEBUG disabled (the win); "DEBUG" enables it (the cost). */
+  @Param({"INFO", "DEBUG"})
+  public String loggerLevel;
+
+  private Logger logger;
+
+  private int statusCode;
+
+  private long durationNanos;
+
+  private String payload;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Logger.Level level = Logger.Level.fromLabel(loggerLevel.toLowerCase(Locale.ROOT));
+    // stdoutEnabled=false, stderrEnabled=false => the logger's output stream is a no-op, so we do
+    // not measure console I/O even in the DEBUG (enabled) scenario.
+    LogSetting logSetting = new LogSetting(level, false, false, null, null, null);
+    LoggerFactory.init(LoggerConfiguration.builder().logSetting(logSetting).build());
+    logger = LoggerFactory.getLogger();
+
+    statusCode = 200;
+    durationNanos = 1_234_567_890L;
+    payload = "instance-identity-document";
+  }
+
+  /** Eager, {@code String.format}: format runs unconditionally, before {@code debug} checks. */
+  @Benchmark
+  public void eagerFormat() {
+    logger.debug(
+        String.format(
+            "Retrieved metadata: status=%d durationNanos=%d payload=%s",
+            statusCode, durationNanos, payload));
+  }
+
+  /** Lazy, {@code String.format}: the supplier is only evaluated when DEBUG is enabled. */
+  @Benchmark
+  public void lazyFormat() {
+    logger.debug(
+        () ->
+            String.format(
+                "Retrieved metadata: status=%d durationNanos=%d payload=%s",
+                statusCode, durationNanos, payload));
+  }
+
+  /**
+   * Eager, string concatenation: the {@code +} expression runs unconditionally, before {@code
+   * debug} checks the level.
+   */
+  @Benchmark
+  public void eagerConcat() {
+    logger.debug(
+        "Retrieved metadata: status="
+            + statusCode
+            + " durationNanos="
+            + durationNanos
+            + " payload="
+            + payload);
+  }
+
+  /** Lazy, string concatenation: the supplier is only evaluated when DEBUG is enabled. */
+  @Benchmark
+  public void lazyConcat() {
+    logger.debug(
+        () ->
+            "Retrieved metadata: status="
+                + statusCode
+                + " durationNanos="
+                + durationNanos
+                + " payload="
+                + payload);
+  }
+}

--- a/bootstrap/src/main/java/com/solarwinds/opentelemetry/core/Util.java
+++ b/bootstrap/src/main/java/com/solarwinds/opentelemetry/core/Util.java
@@ -139,7 +139,7 @@ public class Util {
       try {
         return new URL(url).getPath();
       } catch (MalformedURLException e) {
-        logger.debug("Cannot parse URL " + url);
+        logger.debug(() -> "Cannot parse URL " + url);
       }
     }
     return null;

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsAgentListener.java
@@ -84,10 +84,11 @@ public class SolarwindsAgentListener implements AgentListener {
                         : Collections.<String>emptyList();
 
                 logger.debug(
-                    "Detected host id: "
-                        + HostInfoUtils.getHostId()
-                        + " ip addresses: "
-                        + ipAddresses);
+                    () ->
+                        "Detected host id: "
+                            + HostInfoUtils.getHostId()
+                            + " ip addresses: "
+                            + ipAddresses);
 
                 CountDownLatch settingsLatch =
                     SettingsManager.initialize(
@@ -101,7 +102,7 @@ public class SolarwindsAgentListener implements AgentListener {
                 if (JavaRuntimeVersionChecker.isJdkVersionSupported()
                     && profilerSetting != null
                     && profilerSetting.isEnabled()) {
-                  logger.debug("Profiler is enabled, local settings : " + profilerSetting);
+                  logger.debug(() -> "Profiler is enabled, local settings : " + profilerSetting);
                   Profiler.initialize(
                       profilerSetting,
                       ReporterFactory.getInstance()

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessor.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessor.java
@@ -95,15 +95,17 @@ public class SolarwindsProfilingSpanProcessor implements ExtendedSpanProcessor {
           if (profile.isSampled()) {
             readWriteSpan.setAttribute(SW_KEY_PREFIX + "profile.spans", 1);
             logger.debug(
-                String.format(
-                    "Profiling stopped with sw.profile.spans=1, trace_id=%s span_id=%s",
-                    spanContext.getTraceId(), spanContext.getSpanId()));
+                () ->
+                    String.format(
+                        "Profiling stopped with sw.profile.spans=1, trace_id=%s span_id=%s",
+                        spanContext.getTraceId(), spanContext.getSpanId()));
           } else {
             readWriteSpan.setAttribute(SW_KEY_PREFIX + "profile.spans", 0);
             logger.debug(
-                String.format(
-                    "Profiling stopped with sw.profile.spans=0, trace_id=%s span_id=%s",
-                    spanContext.getTraceId(), spanContext.getSpanId()));
+                () ->
+                    String.format(
+                        "Profiling stopped with sw.profile.spans=0, trace_id=%s span_id=%s",
+                        spanContext.getTraceId(), spanContext.getSpanId()));
           }
         }
       }

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/ConfigurationLoader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/ConfigurationLoader.java
@@ -426,7 +426,8 @@ public class ConfigurationLoader {
                 + ServiceKeyUtils.maskServiceKey(serviceKey));
         configs.put(ConfigProperty.AGENT_SERVICE_KEY, serviceKey, true);
       }
-      logger.debug("Service key (masked) is [" + ServiceKeyUtils.maskServiceKey(serviceKey) + "]");
+      logger.debug(
+          () -> "Service key (masked) is [" + ServiceKeyUtils.maskServiceKey(serviceKey) + "]");
 
     } else {
       if (!configs.containsProperty(ConfigProperty.AGENT_SERVICE_KEY)) {

--- a/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReader.java
+++ b/custom/src/main/java/com/solarwinds/opentelemetry/extensions/config/HttpSettingsReader.java
@@ -54,7 +54,9 @@ public class HttpSettingsReader implements SettingsReader {
     String tokenHeader = String.format("Bearer %s", apiToken);
     Settings fetchedSettings = delegate.fetchSettings(settingsUrl, tokenHeader);
     logger.debug(
-        String.format("Got settings from http: %s, serviceName: %s", fetchedSettings, serviceName));
+        () ->
+            String.format(
+                "Got settings from http: %s, serviceName: %s", fetchedSettings, serviceName));
 
     return fetchedSettings;
   }

--- a/custom/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessorTest.java
+++ b/custom/src/test/java/com/solarwinds/opentelemetry/extensions/SolarwindsProfilingSpanProcessorTest.java
@@ -259,7 +259,6 @@ class SolarwindsProfilingSpanProcessorTest {
     when(mockSpan.getSpanContext()).thenReturn(mockSpanContext);
     when(mockSpanContext.isSampled()).thenReturn(true);
     when(mockSpanContext.getTraceId()).thenReturn(traceId);
-    when(mockSpanContext.getSpanId()).thenReturn(spanId);
     profilerMock.when(Profiler::hasActiveProfiles).thenReturn(true);
 
     when(mockSpan.toSpanData()).thenReturn(mockSpanData);
@@ -283,7 +282,6 @@ class SolarwindsProfilingSpanProcessorTest {
     profilerMock.when(Profiler::hasActiveProfiles).thenReturn(true);
 
     when(mockSpanContext.getTraceId()).thenReturn(traceId);
-    when(mockSpanContext.getSpanId()).thenReturn(spanId);
     when(mockSpan.toSpanData()).thenReturn(mockSpanData);
 
     when(mockSpanData.getParentSpanContext()).thenReturn(mockParentSpanContext);

--- a/instrumentation/instrumentation-shared/src/main/java/com/solarwinds/opentelemetry/instrumentation/StatementTruncator.java
+++ b/instrumentation/instrumentation-shared/src/main/java/com/solarwinds/opentelemetry/instrumentation/StatementTruncator.java
@@ -46,7 +46,7 @@ public class StatementTruncator {
         getAttribute.setAccessible(true);
         sql = (String) getAttribute.invoke(span, DbAttributes.DB_QUERY_TEXT);
       } catch (Throwable throwable) {
-        logger.debug("Cannot execute method getAttribute: " + throwable);
+        logger.debug(() -> "Cannot execute method getAttribute: " + throwable);
       }
       if (sql == null) {
         return;
@@ -60,12 +60,14 @@ public class StatementTruncator {
         sql = sql.substring(0, sqlMaxLength);
         span.setAttribute(QueryTruncatedAttributeKey.KEY, true);
         span.setAttribute(DbAttributes.DB_QUERY_TEXT, sql);
+        int truncatedLength = sql.length();
         logger.debug(
-            "SQL Query trimmed as its length ["
-                + sql.length()
-                + "] exceeds max ["
-                + sqlMaxLength
-                + "]");
+            () ->
+                "SQL Query trimmed as its length ["
+                    + truncatedLength
+                    + "] exceeds max ["
+                    + sqlMaxLength
+                    + "]");
       }
     }
   }

--- a/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigContainer.java
+++ b/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigContainer.java
@@ -125,15 +125,17 @@ public class ConfigContainer {
     if (!override
         && configMap.containsKey(
             propertyKey)) { // the key was already inserted before, do NOT overwrite
-      if (!configMap.get(propertyKey).equals(value)) {
+      Object existingValue = configMap.get(propertyKey);
+      if (!existingValue.equals(value)) {
         logger.debug(
-            "key ["
-                + propertyKey
-                + "] is already defined with value ["
-                + configMap.get(propertyKey)
-                + "]. Ignoring new value ["
-                + value
-                + "]");
+            () ->
+                "key ["
+                    + propertyKey
+                    + "] is already defined with value ["
+                    + existingValue
+                    + "]. Ignoring new value ["
+                    + value
+                    + "]");
       }
     } else {
       if (value == null) { // Do not allow null via put by string value

--- a/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigManager.java
+++ b/libs/config/src/main/java/com/solarwinds/joboe/config/ConfigManager.java
@@ -60,9 +60,10 @@ public class ConfigManager {
   public static Object getConfig(ConfigProperty configKey) {
     if (SINGLETON.configs == null) {
       logger.debug(
-          "Failed to read config property ["
-              + configKey
-              + "] as agent is not initialized properly, config is null!");
+          () ->
+              "Failed to read config property ["
+                  + configKey
+                  + "] as agent is not initialized properly, config is null!");
       return null;
     }
 
@@ -73,9 +74,10 @@ public class ConfigManager {
   public static <T> T getConfigOptional(ConfigProperty configKey, T defaultValue) {
     if (SINGLETON.configs == null) {
       logger.debug(
-          "Failed to read config property ["
-              + configKey
-              + "] as agent is not initialized properly, config is null!");
+          () ->
+              "Failed to read config property ["
+                  + configKey
+                  + "] as agent is not initialized properly, config is null!");
       return defaultValue;
     }
     Object value = SINGLETON.configs.get(configKey);

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/EventImpl.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/EventImpl.java
@@ -244,7 +244,7 @@ public class EventImpl extends Event {
     try {
       addEdge(new Metadata(hexstr));
     } catch (SamplingException ex) {
-      logger.debug("Invalid XTrace ID: " + hexstr, ex);
+      logger.debug(() -> "Invalid XTrace ID: " + hexstr, ex);
     }
   }
 
@@ -308,9 +308,10 @@ public class EventImpl extends Event {
       }
     } catch (EventReporterException e) {
       logger.trace(
-          "Failed to send out event, exception message ["
-              + e.getMessage()
-              + "]. Please take note that existing code flow should not be affected, this might only impact the instrumentation of current trace");
+          () ->
+              "Failed to send out event, exception message ["
+                  + e.getMessage()
+                  + "]. Please take note that existing code flow should not be affected, this might only impact the instrumentation of current trace");
     } catch (Throwable ex) {
       logger.error(
           "Failed to send out event, exception message ["
@@ -433,10 +434,11 @@ public class EventImpl extends Event {
     // will not fully utilize all the space available.
 
     logger.debug(
-        "Trimming KVs on other key count "
-            + otherKeyValues.size()
-            + " maxBytePerKeyValue "
-            + maxBytePerKeyValue);
+        () ->
+            "Trimming KVs on other key count "
+                + otherKeyValues.size()
+                + " maxBytePerKeyValue "
+                + maxBytePerKeyValue);
 
     // test buffer to check accumulative size of the bson document to be built
     ByteBuffer testBuffer =
@@ -506,13 +508,15 @@ public class EventImpl extends Event {
         }
       } else { // not string or object[], not going to trim
         try {
+          int bsonByteSize = getBsonByteSize(entry.getValue());
           logger.debug(
-              "Skip "
-                  + entry.getKey()
-                  + " for trimming as it is type "
-                  + (entry.getValue() != null ? entry.getValue().getClass().getName() : "null ")
-                  + ". Estimated size is "
-                  + getBsonByteSize(entry.getValue()));
+              () ->
+                  "Skip "
+                      + entry.getKey()
+                      + " for trimming as it is type "
+                      + (entry.getValue() != null ? entry.getValue().getClass().getName() : "null ")
+                      + ". Estimated size is "
+                      + bsonByteSize);
         } catch (IllegalArgumentException e) {
           logger.warn(
               "Skip "

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/EventValueConverter.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/EventValueConverter.java
@@ -138,9 +138,10 @@ public class EventValueConverter {
 
     if (converter == null) {
       logger.debug(
-          "Class ["
-              + parameter.getClass().getName()
-              + "] is not in the expected list of classes for PreparedStatement parameter. Using the default handler");
+          () ->
+              "Class ["
+                  + parameter.getClass().getName()
+                  + "] is not in the expected list of classes for PreparedStatement parameter. Using the default handler");
       converter = DEFAULT_HANDLER;
     }
 

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/NonThreadLocalTestReporter.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/NonThreadLocalTestReporter.java
@@ -43,7 +43,7 @@ class NonThreadLocalTestReporter extends TestReporter {
   public synchronized void send(Event event) {
     try {
       byte[] buf = event.toBytes();
-      logger.debug("Sent " + buf.length + " bytes");
+      logger.debug(() -> "Sent " + buf.length + " bytes");
       byteBufferList.add(buf);
     } catch (BsonBufferException e) {
       logger.error("Failed to send events : " + e.getMessage(), e);

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/QueuingEventReporter.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/QueuingEventReporter.java
@@ -96,7 +96,7 @@ public class QueuingEventReporter implements EventReporter {
   static void setFlushInterval(int eventsFlushInterval) {
     if (eventsFlushInterval >= 0) {
       flushInterval = eventsFlushInterval;
-      logger.debug("Event flush interval set to " + eventsFlushInterval + "s");
+      logger.debug(() -> "Event flush interval set to " + eventsFlushInterval + "s");
     } else {
       logger.warn("Event flush interval value " + eventsFlushInterval + " is not valid");
     }
@@ -141,7 +141,7 @@ public class QueuingEventReporter implements EventReporter {
           ResultCode resultCode = result.getResultCode();
 
           if (resultCode.isError()) {
-            logger.debug("Failed to send out " + sendingEvents.size() + " events");
+            logger.debug(() -> "Failed to send out " + sendingEvents.size() + " events");
             stats.incrementFailedCount(sendingEvents.size());
           } else {
             stats.incrementSentCount(sendingEvents.size());
@@ -150,10 +150,11 @@ public class QueuingEventReporter implements EventReporter {
         } catch (Exception e) {
           // do not retry the message, just log the problem
           logger.debug(
-              "Failed to send "
-                  + sendingEvents.size()
-                  + " events, exception found: "
-                  + e.getMessage()); // Should not be too noisy
+              () ->
+                  "Failed to send "
+                      + sendingEvents.size()
+                      + " events, exception found: "
+                      + e.getMessage()); // Should not be too noisy
           stats.incrementFailedCount(sendingEvents.size());
         } finally {
           stats.incrementProcessedCount(sendingEvents.size());
@@ -253,7 +254,7 @@ public class QueuingEventReporter implements EventReporter {
     try {
       client.close();
       boolean termination = executorService.awaitTermination(5, TimeUnit.SECONDS);
-      logger.debug(String.format("Event reporter service shut down: [%s]", termination));
+      logger.debug(() -> String.format("Event reporter service shut down: [%s]", termination));
     } catch (InterruptedException ignored) {
     }
   }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/TestReporter.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/TestReporter.java
@@ -54,7 +54,7 @@ public class TestReporter implements EventReporter {
   public void send(Event event) {
     try {
       byte[] buf = event.toBytes();
-      logger.debug("Sent " + buf.length + " bytes");
+      logger.debug(() -> "Sent " + buf.length + " bytes");
       byteBufList.get().add(buf);
     } catch (BsonBufferException e) {
       logger.error("Failed to send events : " + e.getMessage(), e);

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/profiler/Profiler.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/profiler/Profiler.java
@@ -139,10 +139,11 @@ public class Profiler {
       Profiler.reporter = reporter;
 
       if (interval != 0) {
-        logger.debug("Starting profiler worker, previous status: " + status);
+        logger.debug(() -> "Starting profiler worker, previous status: " + status);
         start();
       } else {
-        logger.debug("No profiling started. Profiler is on standby, previous status: " + status);
+        logger.debug(
+            () -> "No profiling started. Profiler is on standby, previous status: " + status);
       }
 
       addIntervalChangeListener(); // add listener here to avoid race condition on starting the
@@ -206,8 +207,9 @@ public class Profiler {
                   }
                 } catch (InterruptedException e) {
                   logger.debug(
-                      "Profiler interrupted: "
-                          + e.getMessage()); // hard to tell whether this is triggered by JVM
+                      () ->
+                          "Profiler interrupted: "
+                              + e.getMessage()); // hard to tell whether this is triggered by JVM
                   // shutdown
                   status = Status.STOPPING; // flag it to stop
                 } catch (Throwable e) {
@@ -289,7 +291,9 @@ public class Profiler {
 
     if (status != Status.RUNNING) {
       logger.debug(
-          "Add profile thread operation skipped as profiler is not running, status : " + status);
+          () ->
+              "Add profile thread operation skipped as profiler is not running, status : "
+                  + status);
       return false;
     }
 
@@ -302,12 +306,13 @@ public class Profiler {
 
     if (profile.startProfilingOnThread(thread, metadata)) {
       logger.debug(
-          "Started profiling on Thread id: "
-              + thread.getId()
-              + " name: "
-              + thread.getName()
-              + " for trace: "
-              + traceId);
+          () ->
+              "Started profiling on Thread id: "
+                  + thread.getId()
+                  + " name: "
+                  + thread.getName()
+                  + " for trace: "
+                  + traceId);
       return true;
     } else {
       return false;

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/ClientLoggingCallback.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/ClientLoggingCallback.java
@@ -83,13 +83,14 @@ public class ClientLoggingCallback<T extends Result> implements Callback<T> {
                 + "]");
       } else {
         logger.debug(
-            "Completed operation ["
-                + operation
-                + "] with Result code ["
-                + resultCode
-                + "] arg ["
-                + arg
-                + "]");
+            () ->
+                "Completed operation ["
+                    + operation
+                    + "] with Result code ["
+                    + resultCode
+                    + "] arg ["
+                    + arg
+                    + "]");
       }
     }
 

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/ClientManagerProvider.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/ClientManagerProvider.java
@@ -35,7 +35,7 @@ public class ClientManagerProvider {
   }
 
   public static Optional<RpcClientManager> getClientManager(Client.ClientType clientType) {
-    logger.debug("Using " + clientType + " for rpc calls");
+    logger.debug(() -> "Using " + clientType + " for rpc calls");
     return Optional.ofNullable(registeredManagers.get(clientType));
   }
 

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/KeepAliveMonitor.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/KeepAliveMonitor.java
@@ -40,7 +40,8 @@ public class KeepAliveMonitor implements HeartbeatScheduler {
               protocolClient.get().doPing(serviceKey);
               schedule(); // reschedule another keep alive ping
             } catch (Exception e) {
-              LoggerFactory.getLogger().debug("Keep alive ping failed [" + e.getMessage() + "]", e);
+              LoggerFactory.getLogger()
+                  .debug(() -> "Keep alive ping failed [" + e.getMessage() + "]", e);
               // do not re-schedule another keep alive ping if it was having issues
             }
           }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcClient.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcClient.java
@@ -263,8 +263,9 @@ public class RpcClient implements com.solarwinds.joboe.core.rpc.Client {
                   } catch (Exception e) {
                     if (RpcClient.this.isClosing) {
                       logger.debug(
-                          "Found exception during collector Client shutdown. This is probably not critical as the client is shutting down : "
-                              + e.getMessage(),
+                          () ->
+                              "Found exception during collector Client shutdown. This is probably not critical as the client is shutting down : "
+                                  + e.getMessage(),
                           e);
                       return null;
                     } else if (e instanceof ClientRecoverableException) {
@@ -392,10 +393,10 @@ public class RpcClient implements com.solarwinds.joboe.core.rpc.Client {
 
     boolean initClient = !RpcClient.this.isClosing;
     while (initClient) {
-      logger.debug("Creating collector client  : " + host + ":" + port);
+      logger.debug(() -> "Creating collector client  : " + host + ":" + port);
       try {
         protocolClient = protocolClientFactory.buildClient(host, port);
-        logger.debug("Created collector client  : " + host + ":" + port);
+        logger.debug(() -> "Created collector client  : " + host + ":" + port);
 
         connectionStatus = Status.OK;
         return;
@@ -851,14 +852,20 @@ public class RpcClient implements com.solarwinds.joboe.core.rpc.Client {
       shouldRetry = maxRetryCount == null || retryCount <= maxRetryCount;
       if (!shouldRetry) {
         logger.debug(
-            "Not going to retry message as max retry count ["
-                + maxRetryCount
-                + "] is exceeded, cause: "
-                + retryType);
+            () ->
+                "Not going to retry message as max retry count ["
+                    + maxRetryCount
+                    + "] is exceeded, cause: "
+                    + retryType);
         activeDelay = 0;
       } else {
+        int flaggedDelay = delay;
         logger.debug(
-            "Flagging to retry message with delay [" + delay + "] ms, cause: " + retryType);
+            () ->
+                "Flagging to retry message with delay ["
+                    + flaggedDelay
+                    + "] ms, cause: "
+                    + retryType);
         activeDelay = delay;
       }
 
@@ -894,11 +901,12 @@ public class RpcClient implements com.solarwinds.joboe.core.rpc.Client {
       if (shouldRetry) {
         try {
           if (activeDelay > 0) {
-            logger.debug("Collector client retry sleeping for " + activeDelay + " millisecs");
+            logger.debug(() -> "Collector client retry sleeping for " + activeDelay + " millisecs");
             TimeUnit.MILLISECONDS.sleep(activeDelay);
           }
         } catch (InterruptedException e) {
-          logger.debug("Collector client retry sleep is interrupted, message: " + e.getMessage());
+          logger.debug(
+              () -> "Collector client retry sleep is interrupted, message: " + e.getMessage());
           return false; // should not retry if sleep is interrupted
         } finally {
           activeDelay = 0;

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcSettings.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/RpcSettings.java
@@ -88,7 +88,7 @@ public class RpcSettings extends com.solarwinds.joboe.sampling.Settings {
     for (Entry<String, ByteBuffer> inputArg : inputArgs.entrySet()) {
       SettingsArg<?> arg = SettingsArg.fromKey(inputArg.getKey());
       if (arg == null) {
-        logger.debug("Cannot recognize argument [" + inputArg.getKey() + "], ignoring...");
+        logger.debug(() -> "Cannot recognize argument [" + inputArg.getKey() + "], ignoring...");
       } else {
         args.put(arg, arg.readFromByteBuffer(inputArg.getValue()));
       }
@@ -112,7 +112,7 @@ public class RpcSettings extends com.solarwinds.joboe.sampling.Settings {
       } else if ("PROFILING".equals(flagToken)) {
         flags |= OBOE_SETTINGS_FLAG_PROFILING;
       } else {
-        logger.debug("Unknown flag found from settings: " + flagToken);
+        logger.debug(() -> "Unknown flag found from settings: " + flagToken);
       }
     }
     return flags;

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/grpc/GrpcClient.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/rpc/grpc/GrpcClient.java
@@ -177,11 +177,12 @@ public class GrpcClient implements ProtocolClient {
               .setIdentity(hostId)
               .setEncoding(Collector.EncodingType.BSON);
       logger.debug(
-          postAction.getDescription()
-              + " "
-              + itemsAsByteString.size()
-              + " item(s) using gRPC client hostId="
-              + hostId);
+          () ->
+              postAction.getDescription()
+                  + " "
+                  + itemsAsByteString.size()
+                  + " item(s) using gRPC client hostId="
+                  + hostId);
       try {
         builder.addAllMessages(itemsAsByteString);
         resultMessage =
@@ -289,7 +290,7 @@ public class GrpcClient implements ProtocolClient {
           ((String) ConfigManager.getConfig(ConfigProperty.AGENT_GRPC_COMPRESSION));
       compression =
           compressionString != null ? compressionString.toLowerCase() : DEFAULT_COMPRESSION;
-      logger.debug("Using compression " + compression + " for gRPC client");
+      logger.debug(() -> "Using compression " + compression + " for gRPC client");
     }
 
     GrpcProtocolClientFactory(URL serverCertLocation) throws IOException, GeneralSecurityException {

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/settings/PollingSettingsFetcher.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/settings/PollingSettingsFetcher.java
@@ -122,7 +122,7 @@ public class PollingSettingsFetcher implements SettingsFetcher {
                 newSettings = reader.getSettings();
               } catch (OboeSettingsException e) {
                 logger.debug(
-                    "Failed to get settings : " + e.getMessage(),
+                    () -> "Failed to get settings : " + e.getMessage(),
                     e); // Should not be too noisy as this might happen for intermittent connection
                 // problem
               }
@@ -144,9 +144,10 @@ public class PollingSettingsFetcher implements SettingsFetcher {
                 TimeUnit.SECONDS.sleep(refreshInterval); // sleep for the defined interval
               } catch (InterruptedException e) {
                 logger.debug(
-                    PollingSettingsFetcher.class.getName()
-                        + " worker is interrupted : "
-                        + e.getMessage());
+                    () ->
+                        PollingSettingsFetcher.class.getName()
+                            + " worker is interrupted : "
+                            + e.getMessage());
                 running = false;
               }
             }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/settings/RpcSettingsReader.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/settings/RpcSettingsReader.java
@@ -53,7 +53,7 @@ public class RpcSettingsReader implements SettingsReader {
     try {
       result = rpcClient.getSettings(SSL_CLIENT_VERSION, loggingCallback).get();
       if (result.getResultCode() == ResultCode.OK) {
-        logger.debug("Got settings from collector: " + result.getSettings().get(0));
+        logger.debug(() -> "Got settings from collector: " + result.getSettings().get(0));
         return result.getSettings().get(0);
       }
     } catch (Exception e) {

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/BackTraceUtil.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/BackTraceUtil.java
@@ -35,9 +35,10 @@ public class BackTraceUtil {
 
     if (startPosition >= stackTrace.length) {
       logger.debug(
-          "Attempt to skip ["
-              + skipElements
-              + "] elements in addBackTrace is invalid, no stack trace element is left!");
+          () ->
+              "Attempt to skip ["
+                  + skipElements
+                  + "] elements in addBackTrace is invalid, no stack trace element is left!");
       return new StackTraceElement[0];
     }
 

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/ExecUtils.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/ExecUtils.java
@@ -59,7 +59,7 @@ public class ExecUtils {
       String standardResult = inputStreamFuture.get(EXEC_TIMEOUT, TimeUnit.SECONDS);
 
       if (!errorResult.isEmpty()) {
-        logger.debug("exec " + command + " output to error stream : " + errorResult);
+        logger.debug(() -> "exec " + command + " output to error stream : " + errorResult);
       }
 
       return standardResult;

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/HostInfoUtils.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/HostInfoUtils.java
@@ -37,7 +37,8 @@ public class HostInfoUtils {
 
   static {
     for (HostInfoReaderProvider provider : ServiceLoader.load(HostInfoReaderProvider.class)) {
-      logger.debug("Use HostInfoReaderProvider implementation " + provider.getClass().getName());
+      logger.debug(
+          () -> "Use HostInfoReaderProvider implementation " + provider.getClass().getName());
       HostInfoUtils.reader = provider.getHostInfoReader();
       break; // use the first implementation found in the path
     }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/ServerHostInfoReader.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/ServerHostInfoReader.java
@@ -210,7 +210,7 @@ public class ServerHostInfoReader
       }
       String name = line.substring(0, statusStartPoint).trim();
       NicStatus status = NicStatus.fromDesc(line.substring(statusStartPoint).trim());
-      logger.debug("Get device display name=" + name + ", status=" + status);
+      logger.debug(() -> "Get device display name=" + name + ", status=" + status);
       nicStatusMap.put(name, status);
     }
   }
@@ -238,23 +238,25 @@ public class ServerHostInfoReader
           Collections.list(NetworkInterface.getNetworkInterfaces())) {
         try {
           logger.debug(
-              "Found network interface "
-                  + networkInterface.getName()
-                  + " "
-                  + networkInterface.getDisplayName());
+              () ->
+                  "Found network interface "
+                      + networkInterface.getName()
+                      + " "
+                      + networkInterface.getDisplayName());
           if (!networkInterface.isLoopback()
               && !networkInterface.isPointToPoint()
               && isPhysicalInterface(networkInterface)
               && !isGhostHyperV(networkInterface)) {
             logger.debug(
-                "Processing physical network interface "
-                    + networkInterface.getName()
-                    + " "
-                    + networkInterface.getDisplayName());
+                () ->
+                    "Processing physical network interface "
+                        + networkInterface.getName()
+                        + " "
+                        + networkInterface.getDisplayName());
             boolean hasIp = false;
             for (InetAddress address : Collections.list(networkInterface.getInetAddresses())) {
               String ipAddress = address.getHostAddress();
-              logger.debug("Found ip address " + ipAddress);
+              logger.debug(() -> "Found ip address " + ipAddress);
               if (!ips.contains(ipAddress)) {
                 ips.add(ipAddress);
               }
@@ -265,19 +267,21 @@ public class ServerHostInfoReader
               // https://github.com/librato/joboe/pull/1090 for details
               NicStatus status = nicStatusMap.get(networkInterface.getDisplayName());
               logger.debug(
-                  "Checking "
-                      + networkInterface.getName()
-                      + ", "
-                      + networkInterface.getDisplayName()
-                      + ", status="
-                      + status);
+                  () ->
+                      "Checking "
+                          + networkInterface.getName()
+                          + ", "
+                          + networkInterface.getDisplayName()
+                          + ", status="
+                          + status);
               if (!(NicStatus.UP.equals(status) || NicStatus.DISCONNECTED.equals(status))) {
                 // ignore disabled/null NIC on Windows when "-Djava.net.preferIPv4Stack=true" is set
                 logger.debug(
-                    "Ignore disabled/null network adapter "
-                        + networkInterface.getDisplayName()
-                        + ", status="
-                        + status);
+                    () ->
+                        "Ignore disabled/null network adapter "
+                            + networkInterface.getDisplayName()
+                            + ", status="
+                            + status);
                 continue;
               }
               // We cannot simply filter out NICs without an IP for all the scenarios. This is
@@ -291,19 +295,21 @@ public class ServerHostInfoReader
               // it doesn't have an IP address.
               if (NicStatus.UP.equals(status) && !hasIp) {
                 logger.debug(
-                    "Ignore network adapter which is up but no IP assigned: "
-                        + networkInterface.getDisplayName());
+                    () ->
+                        "Ignore network adapter which is up but no IP assigned: "
+                            + networkInterface.getDisplayName());
                 continue;
               }
             } else if (!hasIp) {
-              logger.debug("Ignore network adapter without an IP: " + networkInterface.getName());
+              logger.debug(
+                  () -> "Ignore network adapter without an IP: " + networkInterface.getName());
               continue;
             }
             // add mac addresses too
             byte[] hwAddr = networkInterface.getHardwareAddress();
             if ((hwAddr != null) && (hwAddr.length != 0)) {
               String macAddress = getMacAddressFromBytes(hwAddr);
-              logger.debug("Found MAC address " + macAddress);
+              logger.debug(() -> "Found MAC address " + macAddress);
               if (!macAddresses.contains(macAddress)) {
                 macAddresses.add(macAddress);
               }
@@ -311,18 +317,20 @@ public class ServerHostInfoReader
           }
         } catch (NoSuchMethodError e) {
           logger.debug(
-              "Failed to get network info for "
-                  + networkInterface.getName()
-                  + ", probably running JDK 1.5 or earlier");
+              () ->
+                  "Failed to get network info for "
+                      + networkInterface.getName()
+                      + ", probably running JDK 1.5 or earlier");
         } catch (SocketException e) {
           logger.debug(
-              "Failed to get network info for "
-                  + networkInterface.getName()
-                  + ":"
-                  + e.getMessage());
+              () ->
+                  "Failed to get network info for "
+                      + networkInterface.getName()
+                      + ":"
+                      + e.getMessage());
         }
       }
-      logger.debug("All MAC addresses accepted: " + Arrays.toString(macAddresses.toArray()));
+      logger.debug(() -> "All MAC addresses accepted: " + Arrays.toString(macAddresses.toArray()));
       return new HostInfoUtils.NetworkAddressInfo(ips, macAddresses);
     } catch (SocketException e) {
       logger.warn("Failed to get network info : " + e.getMessage());
@@ -381,7 +389,7 @@ public class ServerHostInfoReader
           && displayName.startsWith(hyperVprefix)
           && !networkInterface.isUp();
     } catch (SocketException e) {
-      logger.debug("Cannot call isUp on " + networkInterface.getDisplayName(), e);
+      logger.debug(() -> "Cannot call isUp on " + networkInterface.getDisplayName(), e);
       return false;
     }
   }
@@ -794,7 +802,8 @@ public class ServerHostInfoReader
       if (instanceId != null) { // only proceed if instance id can be found
         availabilityZone = getResourceOnEndpoint(AVAILABILITY_ZONE_PATH, token);
         logger.debug(
-            "Found EC2 instance id " + instanceId + " availability zone: " + availabilityZone);
+            () ->
+                "Found EC2 instance id " + instanceId + " availability zone: " + availabilityZone);
       }
 
       awsMetadata = getMetadata(token);
@@ -824,17 +833,20 @@ public class ServerHostInfoReader
                   }
 
                   String payload = sb.toString();
-                  logger.debug(String.format("Retrieved metadata using IMDSv1: %s", payload));
+                  logger.debug(() -> String.format("Retrieved metadata using IMDSv1: %s", payload));
                   result.set(payload);
                 }
               } else {
                 logger.debug(
-                    String.format(
-                        "Failed to retrieved metadata using IMDSv1: status code=%d", statusCode));
+                    () ->
+                        String.format(
+                            "Failed to retrieved metadata using IMDSv1: status code=%d",
+                            statusCode));
               }
 
             } catch (IOException exception) {
-              logger.debug(String.format("Error retrieving metadata using IMDSv1: %s", exception));
+              logger.debug(
+                  () -> String.format("Error retrieving metadata using IMDSv1: %s", exception));
             } finally {
               if (connection != null) {
                 connection.disconnect();
@@ -877,12 +889,14 @@ public class ServerHostInfoReader
                 }
               } else {
                 logger.debug(
-                    String.format(
-                        "Failed to retrieved metadata request token: status code=%d", statusCode));
+                    () ->
+                        String.format(
+                            "Failed to retrieved metadata request token: status code=%d",
+                            statusCode));
               }
 
             } catch (IOException e) {
-              logger.debug(String.format("Error getting token for IMDSv2: %s", e));
+              logger.debug(() -> String.format("Error getting token for IMDSv2: %s", e));
             } finally {
               if (connection != null) {
                 connection.disconnect();
@@ -916,17 +930,19 @@ public class ServerHostInfoReader
                     sb.append(line);
                   }
                   String payload = sb.toString();
-                  logger.debug(String.format("Retrieved metadata using IMDSv2: %s", payload));
+                  logger.debug(() -> String.format("Retrieved metadata using IMDSv2: %s", payload));
                   result.set(payload);
                 }
               } else {
                 logger.debug(
-                    String.format(
-                        "Failed to retrieved metadata using IMDSv2: status code=%d", statusCode));
+                    () ->
+                        String.format(
+                            "Failed to retrieved metadata using IMDSv2: status code=%d",
+                            statusCode));
               }
 
             } catch (IOException e) {
-              logger.debug(String.format("Error retrieving metadata using IMDSv2: %s", e));
+              logger.debug(() -> String.format("Error retrieving metadata using IMDSv2: %s", e));
             } finally {
               if (connection != null) {
                 connection.disconnect();
@@ -955,12 +971,13 @@ public class ServerHostInfoReader
           HostId.AwsMetadata metadata =
               HostId.AwsMetadata.fromJson(
                   payload, getResourceOnEndpoint("latest/meta-data/hostname", token));
-          logger.debug(String.format("Aws Metadata: %s", metadata));
+          logger.debug(() -> String.format("Aws Metadata: %s", metadata));
           return metadata;
 
         } catch (JSONException e) {
           logger.debug(
-              String.format("Error converting json to AwsMetadata model: %s\n %s", payload, e));
+              () ->
+                  String.format("Error converting json to AwsMetadata model: %s\n %s", payload, e));
         }
       }
       return null;
@@ -994,7 +1011,7 @@ public class ServerHostInfoReader
       }
 
       if (dockerId != null) {
-        logger.debug("Found Docker instance ID :" + this.dockerId);
+        logger.debug(() -> "Found Docker instance ID :" + this.dockerId);
       } else {
         logger.debug("Cannot locate Docker id, not a Docker container");
       }
@@ -1038,7 +1055,7 @@ public class ServerHostInfoReader
         return Optional.of(containerId);
 
       } else {
-        logger.debug(String.format("No container id in line: {%s}", line));
+        logger.debug(() -> String.format("No container id in line: {%s}", line));
         return Optional.empty();
       }
     }
@@ -1087,7 +1104,7 @@ public class ServerHostInfoReader
     private HerokuDynoReader() {
       this.dynoId = System.getenv(DYNO_ENV_VARIABLE);
       if (this.dynoId != null) {
-        logger.debug("Found Heroku Dyno ID: " + this.dynoId);
+        logger.debug(() -> "Found Heroku Dyno ID: " + this.dynoId);
       }
     }
   }
@@ -1138,7 +1155,7 @@ public class ServerHostInfoReader
               connection.setRequestProperty("Metadata", "true");
               int statusCode = connection.getResponseCode();
 
-              logger.debug(String.format("Azure IMDS status code: %s", statusCode));
+              logger.debug(() -> String.format("Azure IMDS status code: %s", statusCode));
               if (statusCode >= 200 && statusCode < 300) {
                 try (BufferedReader reader =
                     new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
@@ -1150,7 +1167,7 @@ public class ServerHostInfoReader
                   }
 
                   String payload = sb.toString();
-                  logger.debug(String.format("Azure IMDS payload: %s", payload));
+                  logger.debug(() -> String.format("Azure IMDS payload: %s", payload));
                   result.set(HostId.AzureVmMetadata.fromJson(payload));
                 }
               }
@@ -1169,10 +1186,10 @@ public class ServerHostInfoReader
     private AzureReader() {
       this.appInstanceId = System.getenv(INSTANCE_ID_ENV_VARIABLE);
       if (this.appInstanceId != null) {
-        logger.debug("Found Azure instance ID: " + this.appInstanceId);
+        logger.debug(() -> "Found Azure instance ID: " + this.appInstanceId);
       }
       azureVmMetadata = getVmMetadata();
-      logger.debug(String.format("Azure vm metadata: %s", azureVmMetadata));
+      logger.debug(() -> String.format("Azure vm metadata: %s", azureVmMetadata));
     }
   }
 
@@ -1231,7 +1248,7 @@ public class ServerHostInfoReader
               podId = line.substring(matcher.start(), matcher.end());
               logger.info(String.format("Found pod uid: %s", podId));
             } else {
-              logger.debug(String.format("Pod uid not found on line: %s", line));
+              logger.debug(() -> String.format("Pod uid not found on line: %s", line));
             }
             return Optional.ofNullable(podId);
           });
@@ -1257,7 +1274,7 @@ public class ServerHostInfoReader
               .orElse(Optional.empty());
 
     } catch (IOException e) {
-      logger.debug(String.format("Error reading file(%s).  %s", filepath, e.getMessage()));
+      logger.debug(() -> String.format("Error reading file(%s).  %s", filepath, e.getMessage()));
     }
     return value.orElse(null);
   }

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/TimeUtils.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/TimeUtils.java
@@ -115,8 +115,9 @@ public class TimeUtils {
                   }
                 } catch (InterruptedException e) {
                   logger.debug(
-                      "Adjust time worker thread interrupted, probably due to shutdown : "
-                          + e.getMessage());
+                      () ->
+                          "Adjust time worker thread interrupted, probably due to shutdown : "
+                              + e.getMessage());
                 }
               })
           .start();
@@ -155,8 +156,9 @@ public class TimeUtils {
             >= BAD_TIMESTAMP_THRESHOLD) { // avoid endless looping if a system never manage to get 2
           // timestamps within a millisecond
           logger.debug(
-              "Aborting current time adjustment as system appears to be busy. Will try again in next cycle. Bad diffs: "
-                  + badDiffs);
+              () ->
+                  "Aborting current time adjustment as system appears to be busy. Will try again in next cycle. Bad diffs: "
+                      + badDiffs);
           return;
         }
       } else if (diff

--- a/libs/core/src/main/java/com/solarwinds/joboe/core/util/UamsClientIdReader.java
+++ b/libs/core/src/main/java/com/solarwinds/joboe/core/util/UamsClientIdReader.java
@@ -54,7 +54,7 @@ public class UamsClientIdReader {
     } else {
       uamsClientIdPath = Paths.get("/", "opt", "solarwinds", "uamsclient", "var", "uamsclientid");
     }
-    logger.debug("Set uamsclientid path to " + uamsClientIdPath);
+    logger.debug(() -> "Set uamsclientid path to " + uamsClientIdPath);
   }
 
   public static String getUamsClientId() {
@@ -64,10 +64,15 @@ public class UamsClientIdReader {
         lastModified.set(modifiedTime);
         uamsClientId.set(sanitize(readFirstLine(uamsClientIdPath)));
         logger.debug(
-            "Updated uamsclientid to " + uamsClientId.get() + ", lastModifiedTime=" + modifiedTime);
+            () ->
+                "Updated uamsclientid to "
+                    + uamsClientId.get()
+                    + ", lastModifiedTime="
+                    + modifiedTime);
       }
     } catch (IOException e) {
-      logger.debug(String.format("Cannot read the file[%s] due error: %s", uamsClientIdPath, e));
+      logger.debug(
+          () -> String.format("Cannot read the file[%s] due error: %s", uamsClientIdPath, e));
       getUamsClientIdViaRestApi().ifPresent(uamsClientId::set);
     }
     return uamsClientId.get();
@@ -100,18 +105,21 @@ public class UamsClientIdReader {
               String clientId = jsonPayload.getString("uamsclient_id");
 
               logger.debug(
-                  String.format(
-                      "Got UAMS client ID(%s) from API, using hardcoded endpoint", clientId));
+                  () ->
+                      String.format(
+                          "Got UAMS client ID(%s) from API, using hardcoded endpoint", clientId));
               result.set(Optional.ofNullable(clientId));
             } else {
               logger.debug(
-                  String.format(
-                      "Request to UAMS REST endpoint failed. Status=%d, payload=%s",
-                      statusCode, null));
+                  () ->
+                      String.format(
+                          "Request to UAMS REST endpoint failed. Status=%d, payload=%s",
+                          statusCode, null));
             }
 
           } catch (IOException | JSONException exception) {
-            logger.debug(String.format("Error reading from UAMS REST endpoint\n%s", exception));
+            logger.debug(
+                () -> String.format("Error reading from UAMS REST endpoint\n%s", exception));
           } finally {
             if (connection != null) {
               connection.disconnect();
@@ -142,7 +150,7 @@ public class UamsClientIdReader {
       }
       res = id;
     } catch (IllegalArgumentException e) {
-      logger.debug("Discarded invalid UAMS client id: " + id, e);
+      logger.debug(() -> "Discarded invalid UAMS client id: " + id, e);
     }
     return res;
   }

--- a/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/AwsLambdaSettingsFetcher.java
+++ b/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/AwsLambdaSettingsFetcher.java
@@ -47,7 +47,7 @@ public class AwsLambdaSettingsFetcher implements SettingsFetcher {
 
       } catch (SamplingException e) {
         logger.debug(
-            "Failed to get settings : " + e.getMessage(),
+            () -> "Failed to get settings : " + e.getMessage(),
             e); // Should not be too noisy as this might happen for intermittent connection problem
       }
 

--- a/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/FileSettingsReader.java
+++ b/libs/lambda/src/main/java/com/solarwinds/opentelemetry/extensions/FileSettingsReader.java
@@ -51,14 +51,14 @@ public class FileSettingsReader {
       List<Settings> kvSetting =
           JsonSettingWrapper.fromJsonSettings(
               gson.fromJson(new String(bytes, StandardCharsets.UTF_8), type));
-      logger.debug(String.format("Got settings from file: %s", kvSetting));
+      logger.debug(() -> String.format("Got settings from file: %s", kvSetting));
 
       if (!kvSetting.isEmpty()) {
         settings = kvSetting.get(0);
       }
 
     } catch (IOException e) {
-      logger.debug(String.format("Failed to read settings from file, error: %s", e));
+      logger.debug(() -> String.format("Failed to read settings from file, error: %s", e));
       throw new SamplingException("Error reading settings from file");
     }
     return settings;

--- a/libs/logging/src/main/java/com/solarwinds/joboe/logging/FileLoggerStream.java
+++ b/libs/logging/src/main/java/com/solarwinds/joboe/logging/FileLoggerStream.java
@@ -85,7 +85,7 @@ class FileLoggerStream implements LoggerStream, Closeable {
     } else {
       this.logFileLockPath = Paths.get(logFilePath.toString() + ".lock");
     }
-    Logger.INSTANCE.debug("Using " + logFileLockPath + " for log file lock for file rolling");
+    Logger.INSTANCE.debug(() -> "Using " + logFileLockPath + " for log file lock for file rolling");
 
     this.maxSize = maxSizeInBytes;
     this.maxBackup = maxBackup;
@@ -150,7 +150,7 @@ class FileLoggerStream implements LoggerStream, Closeable {
     } catch (RejectedExecutionException e) {
       // use STD_STREAM_LOGGER as we do not want to submit more messages to this file logger
       STD_STREAM_LOGGER.debug(
-          "Failed to log message to file as queue is full " + e.getMessage(), e);
+          () -> "Failed to log message to file as queue is full " + e.getMessage(), e);
     }
   }
 
@@ -168,7 +168,7 @@ class FileLoggerStream implements LoggerStream, Closeable {
     } catch (RejectedExecutionException e) {
       // use STD_STREAM_LOGGER as we do not want to submit more messages to this file logger
       STD_STREAM_LOGGER.debug(
-          "Failed to log message to file as queue is full " + e.getMessage(), e);
+          () -> "Failed to log message to file as queue is full " + e.getMessage(), e);
     }
   }
 
@@ -231,11 +231,12 @@ class FileLoggerStream implements LoggerStream, Closeable {
       try {
         if (shouldRollFile()) { // then see if files should be rolled
           Logger.INSTANCE.debug(
-              "Log file ["
-                  + logFilePath
-                  + "] exceeds "
-                  + (maxSize / 1024 / 1024)
-                  + " MB, attempt to roll the log files.");
+              () ->
+                  "Log file ["
+                      + logFilePath
+                      + "] exceeds "
+                      + (maxSize / 1024 / 1024)
+                      + " MB, attempt to roll the log files.");
           boolean rolled = lockAndRollFile();
           forcedReset = rolled; // always reset the channel if the rolling was successful
         }
@@ -348,7 +349,7 @@ class FileLoggerStream implements LoggerStream, Closeable {
           return new FileLockAndChannel(lock, lockChannel);
         }
       } catch (IOException e) {
-        Logger.INSTANCE.debug("Failed to obtain lockChannel : " + e.getMessage(), e);
+        Logger.INSTANCE.debug(() -> "Failed to obtain lockChannel : " + e.getMessage(), e);
       }
       try {
         TimeUnit.MILLISECONDS.sleep(LOCK_RETRY_SLEEP);

--- a/libs/logging/src/main/java/com/solarwinds/joboe/logging/Logger.java
+++ b/libs/logging/src/main/java/com/solarwinds/joboe/logging/Logger.java
@@ -27,7 +27,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import lombok.Getter;
 
 /**
@@ -136,12 +138,28 @@ public class Logger {
     this.log(Level.DEBUG, message, throwable);
   }
 
+  public void debug(Supplier<String> messageSupplier) {
+    this.log(Level.DEBUG, messageSupplier);
+  }
+
+  public void debug(Supplier<String> messageSupplier, Throwable throwable) {
+    this.log(Level.DEBUG, messageSupplier, throwable);
+  }
+
   public void trace(String message) {
     this.log(Level.TRACE, message);
   }
 
   public void trace(String message, Throwable throwable) {
     this.log(Level.TRACE, message, throwable);
+  }
+
+  public void trace(Supplier<String> messageSupplier) {
+    this.log(Level.TRACE, messageSupplier);
+  }
+
+  public void trace(Supplier<String> messageSupplier, Throwable throwable) {
+    this.log(Level.TRACE, messageSupplier, throwable);
   }
 
   public void log(Level level, String message) {
@@ -159,6 +177,32 @@ public class Logger {
       }
     } else if (shouldLog(level)) {
       print(level, message, t);
+    }
+  }
+
+  public void log(Level level, Supplier<String> messageSupplier) {
+    log(level, messageSupplier, null);
+  }
+
+  /**
+   * Logs a message produced by the given supplier. The supplier is only evaluated when the message
+   * would actually be logged for the given {@code level}, avoiding the cost of constructing the
+   * message (e.g. string concatenation) when it would be discarded.
+   */
+  public void log(Level level, Supplier<String> messageSupplier, Throwable t) {
+    Objects.requireNonNull(messageSupplier, "messageSupplier");
+    if (level == null) {
+      if (shouldLog(Level.ERROR)) { // missing level in the input has severity level of Level.ERROR
+        print(Level.ERROR, "Missing log Level for this log message!");
+      }
+
+      if (shouldLog(
+          DEFAULT_LOGGING)) { // the logging message itself takes the default logging level
+        print(DEFAULT_LOGGING, messageSupplier.get(), t);
+      }
+
+    } else if (shouldLog(level)) {
+      print(level, messageSupplier.get(), t);
     }
   }
 

--- a/libs/logging/src/test/java/com/solarwinds/joboe/logging/LoggerTest.java
+++ b/libs/logging/src/test/java/com/solarwinds/joboe/logging/LoggerTest.java
@@ -17,10 +17,15 @@
 package com.solarwinds.joboe.logging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import lombok.Getter;
 import org.junit.jupiter.api.Test;
 
@@ -272,6 +277,70 @@ public class LoggerTest {
     assertEquals(0, countOccurrence(errMessage, "error-exception"));
     assertEquals(0, countOccurrence(errMessage, "fatal-message"));
     assertEquals(0, countOccurrence(errMessage, "fatal-exception"));
+  }
+
+  @Test
+  public void testLazyMessageNotEvaluatedWhenBelowLevel() throws Exception {
+    Logger logger = new Logger();
+    logger.configure(
+        LoggerConfiguration.builder().logSetting(getLogSetting(Logger.Level.INFO)).build());
+
+    ProxyLoggerStream proxyOutStream = new ProxyLoggerStream();
+    ProxyLoggerStream proxyErrStream = new ProxyLoggerStream();
+    setProxyStreams(logger, proxyOutStream, proxyErrStream);
+
+    AtomicBoolean evaluated = new AtomicBoolean(false);
+    Supplier<String> supplier =
+        () -> {
+          evaluated.set(true);
+          return "debug-lazy-message";
+        };
+
+    logger.debug(supplier);
+    logger.debug(supplier, new Exception("debug-lazy-exception"));
+
+    assertFalse(
+        evaluated.get(), "message supplier should not be evaluated when below the logging level");
+    assertEquals(0, countOccurrence(proxyOutStream.getProxyOutput().toString(), "debug-lazy"));
+  }
+
+  @Test
+  public void testLazyMessageEvaluatedWhenAtLevel() throws Exception {
+    Logger logger = new Logger();
+    logger.configure(
+        LoggerConfiguration.builder().logSetting(getLogSetting(Logger.Level.DEBUG)).build());
+
+    ProxyLoggerStream proxyOutStream = new ProxyLoggerStream();
+    ProxyLoggerStream proxyErrStream = new ProxyLoggerStream();
+    setProxyStreams(logger, proxyOutStream, proxyErrStream);
+
+    AtomicBoolean evaluated = new AtomicBoolean(false);
+    Supplier<String> supplier =
+        () -> {
+          evaluated.set(true);
+          return "debug-lazy-message";
+        };
+
+    logger.debug(supplier);
+    logger.debug(supplier, new Exception("debug-lazy-exception"));
+
+    String outMessage = proxyOutStream.getProxyOutput().toString();
+    assertTrue(evaluated.get(), "message supplier should be evaluated when at the logging level");
+    assertEquals(2, countOccurrence(outMessage, "debug-lazy-message"));
+    assertEquals(1, countOccurrence(outMessage, "debug-lazy-exception"));
+  }
+
+  @Test
+  public void testLazyMessageRejectsNullSupplier() throws Exception {
+    Logger logger = new Logger();
+    logger.configure(
+        LoggerConfiguration.builder().logSetting(getLogSetting(Logger.Level.DEBUG)).build());
+
+    Supplier<String> nullSupplier = null;
+    assertThrows(NullPointerException.class, () -> logger.debug(nullSupplier));
+    assertThrows(
+        NullPointerException.class,
+        () -> logger.debug(nullSupplier, new Exception("debug-lazy-exception")));
   }
 
   private void sendTestMessages(Logger logger) {

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/Metadata.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/Metadata.java
@@ -548,7 +548,7 @@ public class Metadata {
       new Metadata(traceIdHex);
       return true;
     } catch (SamplingException e) {
-      logger.debug("X-Trace ID [" + traceIdHex + "] not compatible : " + e.getMessage());
+      logger.debug(() -> "X-Trace ID [" + traceIdHex + "] not compatible : " + e.getMessage());
       return false;
     }
   }
@@ -620,7 +620,8 @@ public class Metadata {
         random = new XorShiftRng(new DevUrandomSeedGenerator());
       } catch (SeedException e) {
         logger.debug(
-            "Failed to use /dev/urandom as seed generator. Error message : " + e.getMessage());
+            () ->
+                "Failed to use /dev/urandom as seed generator. Error message : " + e.getMessage());
         // try using the SecureRandomSeedGenerator instead
         random = new XorShiftRng(new SecureRandomSeedGenerator());
       }

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/TraceDecisionUtil.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/TraceDecisionUtil.java
@@ -161,14 +161,14 @@ public class TraceDecisionUtil {
 
   private static Metadata validateMetadata(String inXtraceId) {
     if (!Metadata.isCompatible(inXtraceId)) {
-      logger.debug("Not accepting X-Trace ID [" + inXtraceId + "] for trace continuation");
+      logger.debug(() -> "Not accepting X-Trace ID [" + inXtraceId + "] for trace continuation");
       return null;
     }
 
     try {
       Metadata inMetadata = new Metadata(inXtraceId);
       if (!inMetadata.isValid()) {
-        logger.debug("Invalid incoming x-trace ID [" + inXtraceId + "]");
+        logger.debug(() -> "Invalid incoming x-trace ID [" + inXtraceId + "]");
         return null;
       }
       return inMetadata;
@@ -287,7 +287,7 @@ public class TraceDecisionUtil {
   private static double getBucketSettingsArg(Settings settings, SettingsArg<Double> arg) {
     Double value = settings.getArgValue(arg);
     if (value == null) {
-      logger.debug("Cannot read settings arg " + arg);
+      logger.debug(() -> "Cannot read settings arg " + arg);
       return 0;
     } else if (value < 0) {
       logger.warn("Invalid negative value in settings arg " + arg);

--- a/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/XtraceOptions.java
+++ b/libs/sampling/src/main/java/com/solarwinds/joboe/sampling/XtraceOptions.java
@@ -130,8 +130,9 @@ public class XtraceOptions {
 
       if (optionKey.isEmpty()) { // skip empty key
         if (!optionEntry.isEmpty()) {
+          String emptyKeyEntry = optionEntry;
           logger.debug(
-              "Skipped entry [" + optionEntry + "] in X-Trace-Options as the key is empty");
+              () -> "Skipped entry [" + emptyKeyEntry + "] in X-Trace-Options as the key is empty");
         }
         continue;
       }
@@ -146,9 +147,10 @@ public class XtraceOptions {
               options.put(option, true);
             } else {
               logger.debug(
-                  "Duplicated option ["
-                      + option.getKey()
-                      + "] found in X-Trace-Options, ignoring...");
+                  () ->
+                      "Duplicated option ["
+                          + option.getKey()
+                          + "] found in X-Trace-Options, ignoring...");
             }
           }
         } else {
@@ -161,11 +163,12 @@ public class XtraceOptions {
               options.put(option, option.parseValueFromString(optionValueString));
             } else {
               logger.debug(
-                  "Duplicated option ["
-                      + option.getKey()
-                      + "] with value ["
-                      + optionValueString
-                      + "] found in X-Trace-Options, ignoring...");
+                  () ->
+                      "Duplicated option ["
+                          + option.getKey()
+                          + "] with value ["
+                          + optionValueString
+                          + "] found in X-Trace-Options, ignoring...");
             }
           } catch (InvalidValueXtraceOptionException e) {
             exceptions.add(e);

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/ResourceCustomizer.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/ResourceCustomizer.java
@@ -97,7 +97,8 @@ public class ResourceCustomizer implements BiFunction<Resource, ConfigProperties
         ConfigManager.setConfig(
             ConfigProperty.AGENT_SERVICE_KEY, String.format("%s:%s", apiKey, serviceName));
       } catch (InvalidConfigException ignore) {
-        LoggerFactory.getLogger().debug("Failed to update service key with name: " + serviceName);
+        LoggerFactory.getLogger()
+            .debug(() -> "Failed to update service key with name: " + serviceName);
       }
     }
   }

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/SolarwindsSampler.java
@@ -164,7 +164,7 @@ public class SolarwindsSampler implements Sampler {
         TraceStateSamplingResult.wrap(
             samplingResult, additionalAttributesBuilder.build(), xtraceOptionsResponseStr);
 
-    logger.trace(String.format("Sampling decision: %s", result.getDecision()));
+    logger.trace(() -> String.format("Sampling decision: %s", result.getDecision()));
     return result;
   }
 
@@ -191,7 +191,8 @@ public class SolarwindsSampler implements Sampler {
       url = builder.toString();
     }
 
-    logger.trace(String.format("Constructed url: %s", url));
+    String constructedUrl = url;
+    logger.trace(() -> String.format("Constructed url: %s", constructedUrl));
     return url;
   }
 

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/TransactionNameManager.java
@@ -151,14 +151,16 @@ public class TransactionNameManager {
     }
 
     if (!transactionName.equalsIgnoreCase(inputTransactionName)) {
+      String truncatedName = transactionName;
       logger.debug(
-          "Transaction name ["
-              + inputTransactionName
-              + "] was truncated to ["
-              + transactionName
-              + "] because it exceeds "
-              + MAX_TRANSACTION_NAME_LENGTH
-              + " characters.");
+          () ->
+              "Transaction name ["
+                  + inputTransactionName
+                  + "] was truncated to ["
+                  + truncatedName
+                  + "] because it exceeds "
+                  + MAX_TRANSACTION_NAME_LENGTH
+                  + " characters.");
     }
 
     return transactionName;
@@ -168,19 +170,21 @@ public class TransactionNameManager {
     Attributes spanAttributes = spanData.getAttributes();
     String transactionName = spanAttributes.get(TRANSACTION_NAME_KEY);
     if (transactionName != null && !transactionName.isEmpty()) {
-      logger.trace(String.format("Using pre-computed transaction name -> %s", transactionName));
+      String preComputedName = transactionName;
+      logger.trace(
+          () -> String.format("Using pre-computed transaction name -> %s", preComputedName));
       return transactionName;
     }
 
     String custName = CustomTransactionNameDict.get(spanData.getTraceId());
     if (custName != null) {
-      logger.trace(String.format("Using custom transaction name -> %s", custName));
+      logger.trace(() -> String.format("Using custom transaction name -> %s", custName));
       return custName;
     }
 
     String name = namingScheme.createName(spanAttributes);
     if (name != null && !name.isEmpty()) {
-      logger.trace(String.format("Using scheme derived transaction name -> %s", name));
+      logger.trace(() -> String.format("Using scheme derived transaction name -> %s", name));
       return name;
     }
 
@@ -188,14 +192,15 @@ public class TransactionNameManager {
     // MVC)
     String handlerName = spanAttributes.get(handlerNameKey);
     if (handlerName != null) {
-      logger.trace(String.format("Using HandlerName(%s) as the transaction name", handlerName));
+      logger.trace(
+          () -> String.format("Using HandlerName(%s) as the transaction name", handlerName));
       return handlerName;
     }
 
     // use "http.route"
     String httpRoute = spanAttributes.get(HttpAttributes.HTTP_ROUTE);
     if (httpRoute != null) {
-      logger.trace(String.format("Using http.route (%s) as the transaction name", httpRoute));
+      logger.trace(() -> String.format("Using http.route (%s) as the transaction name", httpRoute));
       return httpRoute;
     }
 
@@ -213,10 +218,12 @@ public class TransactionNameManager {
               path, customTransactionNamePattern, false, CUSTOM_TRANSACTION_NAME_PATTERN_SEPARATOR);
 
       if (transactionName != null) {
+        String customPatternName = transactionName;
         logger.trace(
-            String.format(
-                "Using custom configure pattern to extract transaction name: (%s)",
-                transactionName));
+            () ->
+                String.format(
+                    "Using custom configure pattern to extract transaction name: (%s)",
+                    customPatternName));
         return transactionName;
       }
     }
@@ -230,13 +237,15 @@ public class TransactionNameManager {
             DEFAULT_TRANSACTION_NAME_PATTERN_SEPARATOR);
     if (transactionNameByUrl != null) {
       logger.trace(
-          String.format(
-              "Using token name pattern to extract transaction name: (%s)", transactionNameByUrl));
+          () ->
+              String.format(
+                  "Using token name pattern to extract transaction name: (%s)",
+                  transactionNameByUrl));
       return transactionNameByUrl;
     }
 
     String spanName = spanData.getName();
-    logger.trace(String.format("Using span name as the transaction name: (%s)", spanName));
+    logger.trace(() -> String.format("Using span name as the transaction name: (%s)", spanName));
     return spanName;
   }
 
@@ -333,9 +342,10 @@ public class TransactionNameManager {
 
   public static void clearTransactionNames() {
     logger.trace(
-        String.format(
-            "Clearing transaction name buffer. Unique transaction count: %d. Note: This log line is used for validation",
-            EXISTING_TRANSACTION_NAMES.size()));
+        () ->
+            String.format(
+                "Clearing transaction name buffer. Unique transaction count: %d. Note: This log line is used for validation",
+                EXISTING_TRANSACTION_NAMES.size()));
     synchronized (EXISTING_TRANSACTION_NAMES) {
       EXISTING_TRANSACTION_NAMES.clear();
 

--- a/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/JsonSettingWrapper.java
+++ b/libs/shared/src/main/java/com/solarwinds/opentelemetry/extensions/config/JsonSettingWrapper.java
@@ -62,7 +62,7 @@ public class JsonSettingWrapper extends Settings {
       } else if ("PROFILING".equals(flagToken)) {
         flags |= OBOE_SETTINGS_FLAG_PROFILING;
       } else {
-        LoggerFactory.getLogger().debug("Unknown flag found from settings: " + flagToken);
+        LoggerFactory.getLogger().debug(() -> "Unknown flag found from settings: " + flagToken);
       }
     }
     return flags;

--- a/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/NamingSchemeTest.java
+++ b/libs/shared/src/test/java/com/solarwinds/opentelemetry/extensions/NamingSchemeTest.java
@@ -19,7 +19,7 @@ package com.solarwinds.opentelemetry.extensions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -76,7 +76,7 @@ class NamingSchemeTest {
   void verifyThatNullSchemeIsIgnored() {
     try (MockedStatic<LoggerFactory> loggerFactoryMockedStatic = mockStatic(LoggerFactory.class)) {
       loggerFactoryMockedStatic.when(LoggerFactory::getLogger).thenReturn(loggerMock);
-      doNothing().when(loggerMock).debug(any());
+      doNothing().when(loggerMock).debug(anyString());
 
       NamingScheme.createDecisionChain(Collections.singletonList(null));
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,4 +50,5 @@ include("libs:config")
 include("libs:logging")
 include("libs:sampling")
 include("testing:feature-tests")
+include("benchmarks")
 


### PR DESCRIPTION
## TL;DR

`Logger` now supports `Supplier<String>`-based `debug`/`trace` calls, and call sites across
the codebase that built messages via string concatenation or `String.format` pass a lambda
instead of a pre-built string. Message construction is skipped entirely when the level is
disabled, which is the common case in production (default level is `INFO`). A new JMH
benchmark module quantifies the win and explains why `info`/`warn`/`error`/`fatal` were left
eager-only.

## What changed

`Logger` gained `Supplier<String>` overloads for `debug` and `trace` only, backed by a
`log(Level, Supplier<String>, Throwable)` core method that only calls `.get()` after confirming
the level is enabled; a null supplier throws immediately via `Objects.requireNonNull` rather
than failing later in the logging pipeline. `LoggerTest` covers all three cases: supplier not
invoked below threshold, invoked (and message emitted) at threshold, and null rejected up
front.

Every `debug`/`trace` call site whose message was built with `+` concatenation or
`String.format` — spanning event serialization, RPC client/retry logic, host/network/cloud
metadata discovery, config loading, sampling, and transaction naming — now passes `() -> ...`
instead of a pre-built string. `fatal`/`error`/`warn`/`info` call sites were left untouched,
since those levels didn't get lazy overloads (rationale below).

A few call sites needed a small adjustment to satisfy Java's effectively-final capture rule for
lambdas: loop variables that get reassigned, and locals whose value changes later in the same
method, are snapshotted into a dedicated final variable at the point of logging.
`ConfigContainer`'s duplicate-key logging now reads the existing map value once and reuses it
in both the guard condition and the lazy message, instead of hitting the map twice. One test
(`NamingSchemeTest`) has its Mockito stub changed from `any()` to `anyString()` on `debug(...)`,
since an untyped matcher is now ambiguous between the `String` and `Supplier<String>`
overloads.

A new `benchmarks` Gradle module (JMH via `me.champeau.jmh`) benchmarks eager vs. lazy `debug`
calls at both a disabled and an enabled level, for both `String.format` and concatenation-based
messages. The disabled case is where lazy logging wins: the eager call still builds and
discards the message, while the lazy supplier is never invoked. The enabled case measures the
opposite — the lambda-allocation overhead lazy logging adds once the work can't be skipped —
which is why `info`/`warn`/`error`/`fatal`, being effectively always-enabled in practice, were
not given lazy overloads.

One call site's message estimated an entry's BSON-encoded size, a computation that can throw
for unrecognized value types; the surrounding `try/catch` falls back to a `warn` diagnostic on
that failure. That size computation is now performed eagerly, outside the lazy `debug`
supplier, so the exception handling still runs unconditionally regardless of the active log
level — only the message string itself is deferred.


**Test services data**
1. [e-1712644058766987264](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712644058766987264/overview?duration=21600)
2. [e-1712643928659124224](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1712643928659124224/overview?duration=21600)
3. [e-1742334541200846848](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1742334541200846848/logs?duration=21600)
4. [e-1777406072376840192](https://my.na-01.st-ssp.solarwinds.com/205939959869206528/entities/services/e-1777406072376840192/overview?duration=21600)
